### PR TITLE
BUG: adding step to create service-linked role for ELB

### DIFF
--- a/content/deploy/servicerole.md
+++ b/content/deploy/servicerole.md
@@ -1,0 +1,16 @@
+---
+title: "Ensure the ELB Service Role exists"
+date: 2018-09-18T17:40:09-05:00
+weight: 29
+---
+
+In AWS accounts that have never created a load balancer before, it's possible
+that the service role for ELB might not exist yet.
+
+We can check for the role, and create it if it's missing.
+
+Copy/Paste the following commands into your Cloud9 workspace:
+
+```
+aws iam get-role --role-name "AWSServiceRoleForElasticLoadBalancing" || aws iam create-service-linked-role --aws-service-name "elasticloadbalancing.amazonaws.com"
+```


### PR DESCRIPTION
No existing issue -- I discovered this when running through the workshop in a brand new account.
With this missing, this will appear as a hung service deploy for customers in fresh accounts. I recommend merging ASAP to minimize customer impact.

This adds a step to create a service-linked role for ELB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
