### PR TITLE
Update Helm Section to deploy microservices

### DIFF
--- a/content/deploy/cleanup.md
+++ b/content/deploy/cleanup.md
@@ -1,0 +1,23 @@
+---
+title: "Cleanup the applications"
+date: 2018-08-07T13:37:53-07:00
+weight: 90
+---
+
+To delete the resources created by the applications, we should delete the application
+deployments:
+
+Undeploy the applications:
+```
+cd ~/environment/ecsdemo-frontend
+kubectl delete -f kubernetes/service.yaml
+kubectl delete -f kubernetes/deployment.yaml
+
+cd ~/environment/ecsdemo-crystal
+kubectl delete -f kubernetes/service.yaml
+kubectl delete -f kubernetes/deployment.yaml
+
+cd ~/environment/ecsdemo-nodejs
+kubectl delete -f kubernetes/service.yaml
+kubectl delete -f kubernetes/deployment.yaml
+```

--- a/content/helm/_index.md
+++ b/content/helm/_index.md
@@ -4,12 +4,18 @@ chapter: true
 weight: 63
 ---
 
-# Deploy Helm
-
 In this Chapter, we will deploy [Helm](https://helm.sh/) the Kubernetes Package Manager.
 
-[Helm](https://helm.sh/) is a tool for managing Kubernetes charts. Charts are packages of pre-configured Kubernetes resources.
-
-[Helm](https://helm.sh/) is a tool that streamlines installing and managing Kubernetes applications. Think of it like apt/yum/homebrew for Kubernetes.
+# Kubernetes Helm
 
 ![Helm Logo](/images/helm-logo.svg)
+
+[Helm](https://helm.sh/) is a package manager for Kubernetes that packages multiple Kubernetes resources into a single logical deployment unit called **Chart**.
+
+Helm not only is a package manager, but also a Kubernetes application deployment management tool. It helps you to:
+
+- achieve a simple (one command) and repeatable deployment
+- manage application dependency, using specific versions of other application and services
+- manage multiple deployment configurations: test, staging, production and others
+- execute post/pre deployment jobs during application deployment
+- update/rollback and test application deployments

--- a/content/helm/deploy.md
+++ b/content/helm/deploy.md
@@ -1,5 +1,5 @@
 ---
-title: "Using Helm"
+title: "Deploy Helm"
 date: 2018-08-07T08:30:11-07:00
 weight: 10
 ---
@@ -48,62 +48,3 @@ helm init --service-account tiller
 
 This will install **tiller** into the cluster which gives it access to manage
 resources in your cluster.
-
-### Install Demo application
-
-Clone demo application [eksdemo-chart](https://github.com/alexei-led/eksdemo-chart) chart:
-
-```sh
-# clone this repository
-git clone https://github.com/alexei-led/eksdemo-chart
-
-# change working directory
-cd eksdemo-chart
-```
-
-First time application install with release named `workshop`:
-
-```sh
-helm --debug install --name workshop eksdemo
-```
-
-### Update demo application chart
-
-Modify `nodejs.image.repository` to `brentley/ecsdemo-nodejs-non-existing` in `values.yaml` file, setting non-existing Docker image.
-
-Deploy the updated demo application chart:
-
-```sh
-helm upgrade workshop eksdemo
-```
-
-The `eksdemo-nodejs` Pod should fail to pull non-existing image.
-
-Run `helm status` command to see the `ImagePullBackOff` error:
-
-```
-`helm status workshop
-```
-
-### Rollback application
-
-Now we are going to rollback demo application to the previous working release revision.
-
-First, list Helm release revisions:
-
-```
-helm history workshop
-```
-
-Then, rollback to the previous application revision (can rollback to any revision too):
-
-```sh
-# rollback to the 1st revision
-helm rollback workshop 1
-```
-
-Validate `workshop` release status with:
-
-```
-helm status workshop
-```

--- a/content/helm/deploy.md
+++ b/content/helm/deploy.md
@@ -71,15 +71,23 @@ helm --debug install --name workshop eksdemo
 
 Modify `nodejs.image.repository` to `brentley/ecsdemo-nodejs-non-existing` in `values.yaml` file, setting non-existing Docker image.
 
-Deploy an update demo application chart:
+Deploy the updated demo application chart:
 
 ```sh
-helm update --name workshop eksdemo
+helm upgrade workshop eksdemo
 ```
 
-The `eksdemo-nodejs` Pod will fail to pull non-existing image. So, we will rollback to the previous release revision. `helm status workshop` will show `ImagePullBackOff` error for the updated Pod.
+The `eksdemo-nodejs` Pod should fail to pull non-existing image.
 
-Now we are going to rollback to the previous working release revision.
+Run `helm status` command to see the `ImagePullBackOff` error:
+
+```
+`helm status workshop
+```
+
+### Rollback application
+
+Now we are going to rollback demo application to the previous working release revision.
 
 First, list Helm release revisions:
 

--- a/content/helm/deploy.md
+++ b/content/helm/deploy.md
@@ -1,8 +1,10 @@
 ---
-title: "Deploy Helm"
+title: "Using Helm"
 date: 2018-08-07T08:30:11-07:00
 weight: 10
 ---
+
+### Configure Helm access with RBAC
 
 Helm relies on a service called **tiller** that requires special permission on the
 kubernetes cluster, so we need to build a _**Service Account**_ for **tiller**
@@ -46,3 +48,54 @@ helm init --service-account tiller
 
 This will install **tiller** into the cluster which gives it access to manage
 resources in your cluster.
+
+### Install Demo application
+
+Clone demo application [eksdemo-chart](https://github.com/alexei-led/eksdemo-chart) chart:
+
+```sh
+# clone this repository
+git clone https://github.com/alexei-led/eksdemo-chart
+
+# change working directory
+cd eksdemo-chart
+```
+
+First time application install with release named `workshop`:
+
+```sh
+helm --debug install --name workshop eksdemo
+```
+
+### Update demo application chart
+
+Modify `nodejs.image.repository` to `brentley/ecsdemo-nodejs-non-existing` in `values.yaml` file, setting non-existing Docker image.
+
+Deploy an update demo application chart:
+
+```sh
+helm update --name workshop eksdemo
+```
+
+The `eksdemo-nodejs` Pod will fail to pull non-existing image. So, we will rollback to the previous release revision. `helm status workshop` will show `ImagePullBackOff` error for the updated Pod.
+
+Now we are going to rollback to the previous working release revision.
+
+First, list Helm release revisions:
+
+```
+helm history workshop
+```
+
+Then, rollback to the previous application revision (can rollback to any revision too):
+
+```sh
+# rollback to the 1st revision
+helm rollback workshop 1
+```
+
+Validate `workshop` release status with:
+
+```
+helm status workshop
+```

--- a/content/helm/using.md
+++ b/content/helm/using.md
@@ -1,0 +1,163 @@
+---
+title: "Using Helm"
+date: 2018-08-07T08:30:11-07:00
+weight: 20
+---
+#### Deploy our Microservices using Helm
+
+Instead of manually deploying our microservices using `kubectl`, we will create a custom Helm Chart. For detailed information on working with chart templates, refer to the [**Helm docs**](https://docs.helm.sh/chart_template_guide/)
+
+Helm charts are structured like this:
+
+```text
+mychart/
+  Chart.yaml  # a description of the chart
+  values.yaml # the default values for the chart. May be overridden during install or upgrade.
+  charts/ # May contain subcharts
+  templates/ # the template files themselves
+  ...
+```
+
+We'll start out by creating a new chart called **eksdemo**
+```sh
+cd ~/environment
+helm create eksdemo
+```
+
+If you look in the the newly created **eksdemo** directory, you'll see several files and directories. Inside the /templates directory, you'll see these files.
+
+* NOTES.txt: The “help text” for your chart. This will be displayed to your users when they run helm install.
+* deployment.yaml: A basic manifest for creating a Kubernetes deployment
+* service.yaml: A basic manifest for creating a service endpoint for your deployment
+* _helpers.tpl: A place to put template helpers that you can re-use throughout the chart
+
+We're actually going to create our own files, so we'll delete these boilerplate files
+```
+rm -rf ~/environment/eksdemo/templates/*.*
+rm ~/environment/eksdemo/Chart.yaml
+rm ~/environment/eksdemo/values.yaml
+```
+Create a new Chart.yaml file which will describe the chart
+```
+cat <<EoF > ~/environment/eksdemo/Chart.yaml
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for EKS Workshop Microservices application
+name: eksdemo
+version: 0.1.0
+EoF
+```
+
+Now we'll copy the manifest files for each of our microservices into the templates directory as *servicename*.yaml
+```
+#create subfolders for each template type
+mkdir  ~/environment/eksdemo/templates/deployment
+mkdir  ~/environment/eksdemo/templates/service
+
+# Copy and rename frontend manifests
+cp ~/environment/ecsdemo-frontend/kubernetes/deployment.yaml ~/environment/eksdemo/templates/deployment/frontend.yaml
+cp ~/environment/ecsdemo-frontend/kubernetes/service.yaml ~/environment/eksdemo/templates/service/frontend.yaml
+
+# Copy and rename crystal manifests
+cp ~/environment/ecsdemo-crystal/kubernetes/deployment.yaml ~/environment/eksdemo/templates/deployment/crystal.yaml
+cp ~/environment/ecsdemo-crystal/kubernetes/service.yaml ~/environment/eksdemo/templates/service/crystal.yaml
+
+# Copy and rename nodejs manifests
+cp ~/environment/ecsdemo-nodejs/kubernetes/deployment.yaml ~/environment/eksdemo/templates/deployment/nodejs.yaml
+cp ~/environment/ecsdemo-nodejs/kubernetes/service.yaml ~/environment/eksdemo/templates/service/nodejs.yaml
+```
+
+All files in the templates directory are sent through the template engine. These are currently plain YAML files that would be sent to Kubernetes as-is. Let's replace some of the values with `template directives` to enable more customization and start removing hard-coded values.
+
+Open ~/environment/eksdemo/templates/deployment/frontend.yaml in your Cloud9 editor.
+{{% notice info %}}
+You will repeat these steps for **crystal.yaml** and **nodejs.yaml**
+{{% /notice %}}
+Under `spec`, find **replicas: 1**  and replace with the following:
+```
+replicas: {{ .Values.replica }}
+```
+Under `metadata`, replace **namespace: default** with the following:
+```
+namespace: {{ .Values.namespace }}
+```
+Under `spec.template.spec.containers.image`, replace the image with the correct template value from the table below:
+
+|Filename | Value |
+|---|---|
+|frontend.yaml|image: {{ .Values.frontend.image }}:{{ .Values.version }}|
+|crystal.yaml|image: {{ .Values.crystal.image }}:{{ .Values.version }}|
+|nodejs.yaml|image: {{ .Values.nodejs.image }}:{{ .Values.version }}|
+
+#### Create a values.yaml file with our template defaults
+
+This file will populate our `template directives` with default values. 
+```
+cat <<EoF > ~/environment/eksdemo/values.yaml
+# Default values for eksdemo.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Release-wide Values
+replica: 3
+version: 'latest'
+
+# Service Specific Values
+nodejs:
+  image: brentley/ecsdemo-nodejs
+crystal:
+  image: brentley/ecsdemo-crystal
+frontend:
+  image: brentley/ecsdemo-frontend
+EoF
+```
+
+#### Use the dry-run flag to test our templates
+The following command will build and output the rendered templates without installing the chart:
+```sh
+helm install --debug --dry-run --name workshop ~/environment/eksdemo
+```
+Confirm that the values created by the template look correct.
+
+#### Deploy the chart
+Now that we have tested our template, lets install it. 
+```
+helm install --name workshop ~/environment/eksdemo
+```
+#### Update demo application chart with a breaking change
+
+Open **values.yaml** and modify the image name under `nodejs.image.repository` to **brentley/ecsdemo-nodejs-non-existing**. This image does not exist, so this will break our deployment. 
+
+Deploy the updated demo application chart:
+```sh
+helm upgrade workshop ~/environment/eksdemo
+```
+
+The rolling upgrade will begin by creating a new nodejs pod with the new image. The new `ecsdemo-nodejs` Pod should fail to pull non-existing image. Run `helm status` command to see the `ImagePullBackOff` error:
+
+```
+helm status workshop
+```
+
+#### Rollback the failed upgrade
+
+Now we are going to rollback the application to the previous working release revision.
+
+First, list Helm release revisions:
+
+```
+helm history workshop
+```
+
+Then, rollback to the previous application revision (can rollback to any revision too):
+
+```sh
+# rollback to the 1st revision
+helm rollback workshop 1
+```
+
+Validate `workshop` release status with:
+
+```
+helm status workshop
+```


### PR DESCRIPTION
*Issue #, if available:*
#110 and #8 
*Description of changes:*
I moved the Microservices cleanup into that section. I took workflow (test, install, update with broken image, rollback) from #110 but added steps for users to build their own chart and decoupled from external repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
