### PR TITLE
replace ClusterIP with NodePort in output; fix syntax highlighting

### DIFF
--- a/content/monitoring/deploy-prometheus.md
+++ b/content/monitoring/deploy-prometheus.md
@@ -7,16 +7,17 @@ draft: false
 
 #### Download Prometheus
 
-```
+```sh
 curl -o prometheus-values.yaml https://raw.githubusercontent.com/helm/charts/master/stable/prometheus/values.yaml
 ```
+
 Open the prometheus-values.yaml you downloaded by double clicking on the file name on the left panel.
 
 Search for **# storageClass: "-"** in the prometheus-values.yaml, uncomment and change the value to **"prometheus"**. You will do this twice, under both **`server`** & **`alertmanager`** manifests
 
 The manifests will look like below
 
-```
+```yaml
     ## Prometheus server data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -27,7 +28,7 @@ The manifests will look like below
     storageClass: "prometheus"
 ```
 
-```
+```yaml
     ## alertmanager data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -40,7 +41,7 @@ The manifests will look like below
 
 Search for **## List of IP addresses at which the Prometheus server service is available**, add **nodePort: 30900** and change the type to **NodePort** as indicated below. Because Prometheus is exposed as ClusterIP by default, the web UI cannot be reached outside of Kubernetes. The reason we are adding NodePort here is for viewing the web UI from worker node IP address. This configuration is not recommended in Production and there are better ways to secure it. You can read more about exposing Prometheus web UI in this [link](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/exposing-prometheus-and-alertmanager.md)
 
-```
+```yaml
 ## List of IP addresses at which the Prometheus server service is available
 ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
 ##
@@ -52,23 +53,29 @@ servicePort: 80
 nodePort: 30900
 type: NodePort
 ```
+
 #### Deploy Prometheus
-```
+
+```sh
 helm install -f prometheus-values.yaml stable/prometheus --name prometheus --namespace prometheus
 ```
 
 Make a note of prometheus endpoint in helm response (you will need this later). It should look similar to below
 
-```
+```text
 The Prometheus server can be accessed via port 80 on the following DNS name from within your cluster:
 prometheus-server.prometheus.svc.cluster.local
 ```
+
 Check if Prometheus components deployed as expected
-```
+
+```sh
 kubectl get all -n prometheus
 ```
+
 You should see response similar to below. They should all be Ready and Available
-```
+
+```text
 NAME                                                 READY     STATUS    RESTARTS   AGE
 pod/prometheus-alertmanager-77cfdf85db-s9p48         2/2       Running   0          1m
 pod/prometheus-kube-state-metrics-74d5c694c7-vqtjd   1/1       Running   0          1m
@@ -83,7 +90,7 @@ service/prometheus-alertmanager         ClusterIP   10.100.89.154    <none>     
 service/prometheus-kube-state-metrics   ClusterIP   None             <none>        80/TCP     1m
 service/prometheus-node-exporter        ClusterIP   None             <none>        9100/TCP   1m
 service/prometheus-pushgateway          ClusterIP   10.100.136.143   <none>        9091/TCP   1m
-service/prometheus-server               ClusterIP   10.100.151.245   <none>        80/TCP     1m
+service/prometheus-server               NodePort    10.100.151.245   <none>        80/30900   1m
 
 NAME                                      DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
 daemonset.apps/prometheus-node-exporter   3         3         3         3            3           <none>          1m
@@ -99,8 +106,8 @@ replicaset.apps/prometheus-alertmanager-77cfdf85db         1         1         1
 replicaset.apps/prometheus-kube-state-metrics-74d5c694c7   1         1         1         1m
 replicaset.apps/prometheus-pushgateway-d5fdc4f5b           1         1         1         1m
 replicaset.apps/prometheus-server-6d665b876                1         1         1         1m
-
 ```
+
 You can access Prometheus server URL by going to any one of your Worker node IP address and specify port **:30900/targets** (for ex, 52.12.161.128:30900/targets. Remember to open port **30900** in your Worker nodes Security Group. In the web UI, you can see all the targets and metrics being monitored by Prometheus
 
 ![prometheus-targets](/images/prometheus-targets.png)


### PR DESCRIPTION
*Issue #, if available:*
Wrong service type for `prometheus-server` `ClusterIP`

*Description of changes:*

Changed `prometheus-server` service type (in output) for `NodePort`

p.s.: also fixed syntax highlighting in markdown for the updated page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
