### PR TITLE
Simplify CFN stack creation shortcode

### DIFF
--- a/content/codepipeline/codepipeline.md
+++ b/content/codepipeline/codepipeline.md
@@ -21,7 +21,7 @@ Click the **Launch** button to create the CloudFormation stack in the AWS Manage
 
 | Launch template |  |  |
 | ------ |:------:|:--------:|
-| CodePipeline & EKS |  {{% cf-launch "ci-cd-codepipeline.cfn.yml?stackName=eksws-codepipeline" %}} | {{% cf-download "ci-cd-codepipeline.cfn.yml" %}}  |
+| CodePipeline & EKS |  {{% cf-launch "ci-cd-codepipeline.cfn.yml" "eksws-codepipeline" %}} | {{% cf-download "ci-cd-codepipeline.cfn.yml" %}}  |
 
 After the console is open, enter your GitHub username, personal access token (created in previous step), check the acknowledge box and then click the "Create" button.
 

--- a/layouts/shortcodes/cf-launch.html
+++ b/layouts/shortcodes/cf-launch.html
@@ -1,6 +1,6 @@
-<a 
-href="https://console.aws.amazon.com/cloudformation/home?#/stacks/new?templateURL=https://s3.amazonaws.com/{{ $.Site.Params.template_bucket  }}/templates/{{ $.Site.Params.branch  }}/{{ .Get 0 }}" 
-target="_blank" class="btn btn-default"> 
-<i class="fas fa-cloud-upload-alt"></i> 
+<a
+  href="https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName={{ .Get 1 }}&templateURL=https://s3.amazonaws.com/{{ $.Site.Params.template_bucket  }}/templates/{{ $.Site.Params.branch  }}/{{ .Get 0 }}"
+target="_blank" class="btn btn-default">
+<i class="fas fa-cloud-upload-alt"></i>
 Launch
 </a>


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

This modifies the cf-launch shortcode to accept a stack name and to use the quickcreate link to simplify CFN stack launches. So far, this is only used in the CI/CD module, so this PR does not impact other modules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
