### PR TITLE
Updated istio version

### DIFF
--- a/content/servicemesh/download.md
+++ b/content/servicemesh/download.md
@@ -13,7 +13,7 @@ cd ~/environment
 curl -L https://git.io/getLatestIstio | sh -
 
 // version can be different as istio gets upgraded
-cd istio-1.0.3
+cd istio-*
 
 sudo mv -v bin/istioctl /usr/local/bin/
 ```


### PR DESCRIPTION

*Issue: hardcoded version in the bash script now fails due to new releases

*Description of changes: The current version that's grabbed is 1.0.4, so I've quickly updated the command to make it easier in the interim.
