### PR TITLE
update istio version to reflect the url link

### DIFF
--- a/content/servicemesh/download.md
+++ b/content/servicemesh/download.md
@@ -13,7 +13,7 @@ cd ~/environment
 curl -L https://git.io/getLatestIstio | sh -
 
 // version can be different as istio gets upgraded
-cd istio-1.0.3
+cd istio-1.0.4
 
 sudo mv -v bin/istioctl /usr/local/bin/
 ```


### PR DESCRIPTION
Without this change the tutorial breaks.
The URL https://git.io/getLatestIstio now pulls down istio-1.0.4
The other option is to use a URL that points specifically to the 1.0.3 version.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
