### PR TITLE
Update mkdir command

### DIFF
--- a/content/helm_root/helm_micro/customize.md
+++ b/content/helm_root/helm_micro/customize.md
@@ -31,8 +31,8 @@ EoF
 Next we'll copy the manifest files for each of our microservices into the templates directory as *servicename*.yaml
 ```
 #create subfolders for each template type
-mkdir  ~/environment/eksdemo/templates/deployment
-mkdir  ~/environment/eksdemo/templates/service
+mkdir -p ~/environment/eksdemo/templates/deployment
+mkdir -p ~/environment/eksdemo/templates/service
 
 # Copy and rename frontend manifests
 cp ~/environment/ecsdemo-frontend/kubernetes/deployment.yaml ~/environment/eksdemo/templates/deployment/frontend.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The change in #208 caused the `templates/` folder to be removed completely, now causing the `mkdir` statements on the same module to fail (since `mkdir` won't automatically create subfolders). This change is adding the `-p` flag to let `mkdir` create subfolders.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
