### PR TITLE
STACK_NAME is not hardcoded anymore

### DIFF
--- a/content/scaling/deploy_ca.md
+++ b/content/scaling/deploy_ca.md
@@ -64,7 +64,8 @@ We need to configure an inline policy and add it to the EC2 instance profile of 
 
 Collect the Instance Profile and Role NAME from the CloudFormation Stack
 ```
-INSTANCE_PROFILE_PREFIX=$(aws cloudformation describe-stacks --stack-name eksctl-eksworkshop-eksctl-nodegroup-0 | jq -r '.Stacks[].Outputs[].ExportName' | sed 's/:.*//')
+STACK_NAME=`aws cloudformation list-stacks | jq -r '.StackSummaries[].StackName' | grep 'eksctl-eksworkshop-eksctl-nodegroup-ng-'`
+INSTANCE_PROFILE_PREFIX=$(aws cloudformation describe-stacks --stack-name ${STACK_NAME} | jq -r '.Stacks[].Outputs[].ExportName' | sed 's/:.*//')
 INSTANCE_PROFILE_NAME=$(aws iam list-instance-profiles | jq -r '.InstanceProfiles[].InstanceProfileName' | grep $INSTANCE_PROFILE_PREFIX)
 ROLE_NAME=$(aws iam get-instance-profile --instance-profile-name $INSTANCE_PROFILE_NAME | jq -r '.InstanceProfile.Roles[] | .RoleName')
 ```


### PR DESCRIPTION
The stack name is dynamic and not hardcoded anymore, using list-stacks I grep the name consider that we have only one eksworkshop and than use it on the other commands

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
