### PR TITLE
Updated GitHub URL to Dashboard YAML

### DIFF
--- a/content/dashboard/dashboard.md
+++ b/content/dashboard/dashboard.md
@@ -9,7 +9,9 @@ instructions in [the official documentation](https://kubernetes.io/docs/tasks/ac
 
 We can deploy the dashboard with the following command:
 ```
-kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
+kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
+
+
 ```
 
 Since this is deployed to our private cluster, we need to access it via a proxy.


### PR DESCRIPTION

*Issue #, if available:*
N/A 

*Description of changes:*
Updating Dashboard URL to pull from a tag as Master branch is undergoing folder structure changes. 


When you run (as instructed)

`kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml`

you receive the following output

`error: unable to read URL "https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml", server reported 404 Not Found, status code=404`





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
