### PR TITLE
update ECR console URL

### DIFF
--- a/content/codepipeline/cleanup.md
+++ b/content/codepipeline/cleanup.md
@@ -23,7 +23,7 @@ Check the box next to the **eksws-codepipeline** stack, select the **Actions** d
 
 ![CloudFormation Delete](/images/codepipeline/cloudformation_delete.png)
 
-Now we are going to delete the [ECR repository](https://console.aws.amazon.com/ecs/home#/repositories):
+Now we are going to delete the [ECR repository](https://console.aws.amazon.com/ecr/home#/repositories):
 
 ![ECR Delete](/images/codepipeline/ecr_delete.png)
 


### PR DESCRIPTION
ECR is now in an independent AWS console location

*Issue #, if available:*

*Description of changes:*
removes risk of breaking if redirect from /ecs/repositories > /ecr is removed 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
