### PR TITLE
Tigera branch backport of current msater

### DIFF
--- a/content/dashboard/_index.md
+++ b/content/dashboard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy the Kubernetes Dashboard"
 chapter: true
-weight: 50
+weight: 30
 ---
 
 # Deploy the Kubernetes Dashboard

--- a/content/dashboard/connect.md
+++ b/content/dashboard/connect.md
@@ -8,7 +8,10 @@ Now we can access the Kubernetes Dashboard
 
 1. In your Cloud9 environment, click **Preview / Preview Running Application**
 1. Scroll to **the end of the URL** and append:
-```/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/```
+
+```
+/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/
+```
 
 Open a New Terminal Tab  and enter
 ```
@@ -16,7 +19,7 @@ aws-iam-authenticator token -i eksworkshop-eksctl --token-only
 ```
 
 Copy the output of this command and then *click* the radio button next to
-*Token* then in the text field below pate the output from the last command.
+*Token* then in the text field below paste the output from the last command.
 
 ![Token page](/images/dashboard-connect.png)
 

--- a/content/dashboard/dashboard.md
+++ b/content/dashboard/dashboard.md
@@ -9,7 +9,7 @@ instructions in [the official documentation](https://kubernetes.io/docs/tasks/ac
 
 We can deploy the dashboard with the following command:
 ```
-kubectl create -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
 ```
 
 Since this is deployed to our private cluster, we need to access it via a proxy.
@@ -22,7 +22,7 @@ kubectl proxy --port=8080 --address='0.0.0.0' --disable-filter=true &
 This will start the proxy, listen on port 8080, listen on all interfaces, and
 will disable the filtering of non-localhost requests.
 
-Leave this running in your current terminal tab, and open a new terminal tab to continue.
+This command will continue to run in the background of the current terminal's session.
 
 {{% notice warning %}}
 We are disabling request filtering, a security feature that guards against XSRF attacks.

--- a/content/deploy/_index.md
+++ b/content/deploy/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy the Example Microservices"
 chapter: true
-weight: 60
+weight: 31
 ---
 
 # Deploy the Example Microservices

--- a/content/deploy/cleanup.md
+++ b/content/deploy/cleanup.md
@@ -1,0 +1,23 @@
+---
+title: "Cleanup the applications"
+date: 2018-08-07T13:37:53-07:00
+weight: 90
+---
+
+To delete the resources created by the applications, we should delete the application
+deployments:
+
+Undeploy the applications:
+```
+cd ~/environment/ecsdemo-frontend
+kubectl delete -f kubernetes/service.yaml
+kubectl delete -f kubernetes/deployment.yaml
+
+cd ~/environment/ecsdemo-crystal
+kubectl delete -f kubernetes/service.yaml
+kubectl delete -f kubernetes/deployment.yaml
+
+cd ~/environment/ecsdemo-nodejs
+kubectl delete -f kubernetes/service.yaml
+kubectl delete -f kubernetes/deployment.yaml
+```

--- a/content/eksctl/launcheks.md
+++ b/content/eksctl/launcheks.md
@@ -4,6 +4,32 @@ date: 2018-08-07T13:34:24-07:00
 weight: 20
 ---
 
+
+{{% notice warning %}}
+**DO NOT PROCEED** with this step unless you have [validated the IAM role](/prerequisites/workspaceiam/#validate-the-iam-role) in use by the Cloud9 IDE. You will not be able to run the necessary kubectl commands in the later modules unless the EKS cluster is built using the IAM role.
+{{% /notice %}}
+
+#### Challenge:
+**How do I check the IAM role on the workspace?**
+
+{{%expand "Expand here to see the solution" %}}
+Run `aws sts get-caller-identity` and validate that your _Arn_ contains `modernizer-workshop-cl9` (or the role created when starting the workshop) and an Instance Id.
+
+```output
+{
+    "Account": "123456789012", 
+    "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef", 
+    "Arn": "arn:aws:sts::123456789012:assumed-role/modernizer-workshop-cl9/i-01234567890abcdef"
+}
+```
+
+If you do not see the correct role, please go back and [validate the IAM role](/prerequisites/workspaceiam/#validate-the-iam-role) for troubleshooting.
+
+If you do see the correct role, proceed to next step to create an EKS cluster.
+{{% /expand %}}
+
+### Create an EKS cluster
+
 To create a basic EKS cluster, run:
 ```
 eksctl create cluster --name=eksworkshop-eksctl --nodes=3 --node-ami=auto --region=${AWS_REGION}

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -1,11 +1,24 @@
 ---
 title: "Introduction"
-chapter: true
 weight: 5
+chapter: true
+draft: false
 ---
 
-# Welcome!
+# Introduction to Kubernetes
 
-![EKS](/images/eks-product-page.png)
+A walkthrough of basic Kubernetes concepts.
 
-This workshop is designed to educate engineers that might not be familiar with Amazon EKS, Kubernetes, and possibly even Docker container workflow.
+![Title Image](/images/introduction/eks-product-page.png)
+
+Welcome to the Amazon EKS Workshop!
+
+The intent of this workshop is to educate users about the features of Amazon EKS.
+
+Background in EKS, Kubernetes, Docker, and container workflows are not required, but they are recommended.
+
+This chapter will introduce you to the basic workings of Kubernetes, laying the foundation for the hands-on portion of the workshop.
+
+Specifically, we will walk you through the following topics:
+
+{{% children showhidden="false" %}}

--- a/content/introduction/architecture/_index.md
+++ b/content/introduction/architecture/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Kubernetes Architecture"
+date: 2018-10-03T10:17:52-07:00
+draft: false
+weight: 80
+---
+
+In this section, we'll cover the following topics:
+
+{{% children showhidden="false" %}}

--- a/content/introduction/architecture/architecture_control.md
+++ b/content/introduction/architecture/architecture_control.md
@@ -1,0 +1,40 @@
+---
+title: "Control Plane"
+date: 2018-10-03T10:18:27-07:00
+draft: false
+weight: 100
+---
+
+{{<mermaid>}}
+graph TB
+kubectl{kubectl}
+  subgraph ControlPlane
+    api(API Server)
+    controller(Controller Manager)
+    scheduler(Scheduler)
+    etcd(etcd)
+  end
+
+  kubectl-->api
+  controller-->api
+  scheduler-->api
+  api-->kubelet
+  api-->etcd
+
+  classDef green fill:#9f6,stroke:#333,stroke-width:4px;
+  classDef orange fill:#f96,stroke:#333,stroke-width:4px;
+  classDef blue fill:#6495ed,stroke:#333,stroke-width:4px;
+  class api blue;
+  class internet green;
+  class kubectl orange;
+{{< /mermaid >}}
+
+* One or More API Servers: Entry point for REST / kubectl
+
+* etcd: Distributed key/value store
+
+* Controller-manager: Always evaluating current vs desired state
+
+* Scheduler: Schedules pods to worker nodes
+
+Check out [the official Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/components/#master-components) for a more in-depth explanation of control plane components.

--- a/content/introduction/architecture/architecture_control_and_data_overview.md
+++ b/content/introduction/architecture/architecture_control_and_data_overview.md
@@ -1,0 +1,48 @@
+---
+title: "Architectural Overview"
+date: 2018-10-03T10:18:20-07:00
+draft: false
+weight: 90
+---
+
+{{<mermaid>}}
+graph TB
+internet((internet))
+kubectl{kubectl}
+  subgraph ControlPlane
+    api(API Server)
+    controller(Controller Manager)
+    scheduler(Scheduler)
+    etcd(etcd)
+  end
+    subgraph worker1
+      kubelet1(kubelet)
+      kube-proxy1(kube-proxy)
+      subgraph docker1
+        subgraph podA
+          containerA[container]
+        end
+        subgraph podB
+          containerB[container]
+        end
+      end
+    end
+
+  internet-->kube-proxy1
+  kubectl-->api
+  controller-->api
+  scheduler-->api
+  api-->kubelet1
+  api-->etcd
+  kubelet1-->containerA
+  kubelet1-->containerB
+  kube-proxy1-->containerA
+  kube-proxy1-->containerB
+
+  classDef green fill:#9f6,stroke:#333,stroke-width:4px;
+  classDef orange fill:#f96,stroke:#333,stroke-width:4px;
+  classDef blue fill:#6495ed,stroke:#333,stroke-width:4px;
+  class api blue;
+  class internet green;
+  class kubectl orange;
+{{< /mermaid >}}

--- a/content/introduction/architecture/architecture_worker.md
+++ b/content/introduction/architecture/architecture_worker.md
@@ -1,0 +1,45 @@
+---
+title: "Data Plane"
+date: 2018-10-03T10:18:27-07:00
+draft: false
+weight: 110
+---
+
+{{<mermaid>}}
+graph TB
+internet((internet))
+    subgraph worker1
+      kubelet1(kubelet)
+      kube-proxy1(kube-proxy)
+      subgraph docker1
+        subgraph podA
+          containerA[container]
+        end
+        subgraph podB
+          containerB[container]
+        end
+      end
+    end
+
+  internet-->kube-proxy1
+  api-->kubelet1
+  kubelet1-->containerA
+  kubelet1-->containerB
+  kube-proxy1-->containerA
+  kube-proxy1-->containerB
+
+  classDef green fill:#9f6,stroke:#333,stroke-width:4px;
+  classDef orange fill:#f96,stroke:#333,stroke-width:4px;
+  classDef blue fill:#6495ed,stroke:#333,stroke-width:4px;
+  class api blue;
+  class internet green;
+  class kubectl orange;
+{{< /mermaid >}}
+
+* Made up of worker nodes
+
+* kubelet: Acts as a conduit between the API server and the node
+
+* kube-proxy: Manages IP translation and routing
+
+Check out [the official Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/components/#node-components) for a more in-depth explanation of data plane components.

--- a/content/introduction/architecture/cluster_setup_options.md
+++ b/content/introduction/architecture/cluster_setup_options.md
@@ -1,0 +1,18 @@
+---
+title: "Kubernetes Cluster Setup"
+date: 2018-10-03T10:21:11-07:00
+draft: false
+weight: 120
+---
+
+
+In addition to the managed Amazon EKS solution, there are many tools available to help bootstrap and configure a self-managed Kubernetes cluster.  They include:
+
+* [Minikube](https://kubernetes.io/docs/setup/minikube/) – Development and Learning
+* [Kops](https://github.com/kubernetes/kops) – Learning, Development, Production
+* [Kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/) – Learning, Development, Production
+* [Docker for Mac](https://docs.docker.com/docker-for-mac/#kubernetes) - Learning, Development
+
+Alongside these open source solutions, there are also many commercial options available.
+
+Let's take a look at Amazon EKS!

--- a/content/introduction/basics/_index.md
+++ b/content/introduction/basics/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Kubernetes (k8s) Basics"
+date: 2018-10-03T10:14:32-07:00
+draft: false
+weight: 20
+---
+
+In this section, we'll cover the following topics:
+
+{{% children showhidden="false" %}}
+

--- a/content/introduction/basics/concepts_nodes.md
+++ b/content/introduction/basics/concepts_nodes.md
@@ -1,0 +1,18 @@
+---
+title: "Kubernetes Nodes"
+date: 2018-10-03T10:15:55-07:00
+draft: false
+weight: 40
+---
+
+The machines that make up a Kubernetes cluster are called **nodes**.
+
+Nodes in a Kubernetes cluster may be physical, or virtual.  
+
+There are two types of nodes:
+
+* A Master-node type, which makes up the [Control Plane](../../architecture/architecture_control), acts as the “brains” of the cluster.
+
+* A Worker-node type, which makes up the [Data Plane](../../architecture/architecture_worker), runs the actual container images (via pods.)
+
+We’ll dive deeper into how nodes interact with each other later in the presentation.

--- a/content/introduction/basics/concepts_objects.md
+++ b/content/introduction/basics/concepts_objects.md
@@ -1,0 +1,19 @@
+---
+title: "K8s Objects Overview"
+date: 2018-10-03T10:15:55-07:00
+draft: false
+weight: 50
+---
+
+Kubernetes objects are entities that are used to represent the state of the cluster.  
+
+An object is a “record of intent” – once created, the cluster does its best to ensure it exists as defined.  This is known as the cluster’s “desired state.”
+
+Kubernetes is always working to make an object’s “current state” equal to the object’s “desired state.”  A desired state can describe:
+
+* What pods (containers) are running, and on which nodes
+* IP endpoints that map to a logical group of containers
+* How many replicas of a container are running
+* And much more...
+
+Let’s explain these k8s objects in a bit more detail...

--- a/content/introduction/basics/concepts_objects_details_1.md
+++ b/content/introduction/basics/concepts_objects_details_1.md
@@ -1,0 +1,16 @@
+---
+title: "K8s Objects Detail (1/2)"
+date: 2018-10-03T10:15:55-07:00
+draft: false
+weight: 60
+---
+
+### [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod/)
+* A thin wrapper around one or more containers
+
+### [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+
+* Implements a single instance of a pod on a worker node
+
+### [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+* Details how to roll out (or roll back) across versions of your application

--- a/content/introduction/basics/concepts_objects_details_2.md
+++ b/content/introduction/basics/concepts_objects_details_2.md
@@ -1,0 +1,18 @@
+---
+title: "K8s Objects Detail (2/2)"
+date: 2018-10-03T10:15:55-07:00
+draft: false
+weight: 70
+---
+
+### [ReplicaSet](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)
+* Ensures a defined number of pods are always running
+
+### [Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+* Ensures a pod properly runs to completion
+
+### [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+* Maps a fixed IP address to a logical group of pods
+
+### [Label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+* Key/Value pairs used for association and filtering

--- a/content/introduction/basics/what_is_k8s.md
+++ b/content/introduction/basics/what_is_k8s.md
@@ -1,0 +1,14 @@
+---
+title: "What is Kubernetes?"
+date: 2018-10-03T10:14:46-07:00
+draft: false
+weight: 30
+---
+
+![K8s summary image](/images/introduction/what_is_k8s_new.png)
+
+* Builds on over a decade of experience and best practices
+* Utilizes declarative configuration and automation
+* Draws upon a large ecosystem of tools, services, support
+
+More information on what Kubernetes is all about can be found on the [official Kubernetes website](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/). 

--- a/content/introduction/eks/_index.md
+++ b/content/introduction/eks/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Amazon EKS"
+date: 2018-10-03T10:14:32-07:00
+draft: false
+weight: 90
+---
+
+In this section, we'll cover the following topics:
+
+{{% children showhidden="false" %}}
+

--- a/content/introduction/eks/eks_control_plane.md
+++ b/content/introduction/eks/eks_control_plane.md
@@ -1,0 +1,9 @@
+---
+title: "What happens when you create your EKS cluster"
+date: 2018-10-03T10:23:24-07:00
+draft: false
+weight: 140
+---
+
+
+![EKS Control Plane](/images/introduction/eks-k8s-control-plane.svg)

--- a/content/introduction/eks/eks_customers.md
+++ b/content/introduction/eks/eks_customers.md
@@ -1,0 +1,9 @@
+---
+title: "EKS Cluster Creation Workflow"
+date: 2018-10-03T10:23:24-07:00
+draft: false
+weight: 130
+---
+
+
+![EKS Customers](/images/introduction/eks-customers.svg)

--- a/content/introduction/eks/eks_high_architecture.md
+++ b/content/introduction/eks/eks_high_architecture.md
@@ -1,0 +1,9 @@
+---
+title: "EKS Architecture for Control plane and Worker node communication"
+date: 2018-10-03T10:23:24-07:00
+draft: false
+weight: 150
+---
+
+
+![EKS Architecture](/images/introduction/eks-architecture.svg)

--- a/content/introduction/eks/eks_high_level.md
+++ b/content/introduction/eks/eks_high_level.md
@@ -1,0 +1,11 @@
+---
+title: "High Level"
+date: 2018-10-03T10:23:24-07:00
+draft: false
+weight: 150
+---
+
+
+Once your EKS cluster is ready, you get an API endpoint and you'd [use Kubectl, community developed tool to interact with your cluster.](https://kubernetes.io/docs/reference/kubectl/kubectl/)
+
+![EKS High Level](/images/introduction/eks-high-level.svg)

--- a/content/introduction/eks/stay_tuned.md
+++ b/content/introduction/eks/stay_tuned.md
@@ -1,0 +1,10 @@
+---
+title: "Amazon EKS!"
+date: 2018-10-03T10:23:24-07:00
+draft: false
+weight: 160
+---
+
+Stay tuned as we continue the journey with EKS in the next module!
+
+Always ask questions!  Feel free to ask them in person during this workshop, or any time on the official Kubernetes Slack channel accessible via http://slack.k8s.io/.

--- a/content/prerequisites/_index.md
+++ b/content/prerequisites/_index.md
@@ -1,9 +1,15 @@
 ---
-title: "Prerequisites"
+title: "Start the workshop..."
 chapter: true
 weight: 10
 ---
 
-# Prerequisites for the Workshop
+# Getting Started
 
-{{% children showhidden="false" %}}
+To start the workshop, follow one of the following depending on whether you are...
+
+* ...[running the workshop on your own](self_paced/), or
+* ...[attending an AWS hosted event](aws_event/)
+
+
+Once you have completed with either setup, continue with [**Create a SSH key section**](/prerequisites/sshkey/)

--- a/content/prerequisites/aws_event/_index.md
+++ b/content/prerequisites/aws_event/_index.md
@@ -1,0 +1,13 @@
+---
+title: "...at an AWS event"
+chapter: true
+weight: 12
+---
+
+### Running the workshop at an AWS Event
+
+{{% notice warning %}}
+Only complete this section if you are at an AWS hosted event (such as re:Invent, Kubecon, Immersion Day, etc). If you are running the workshop on your own, go to [Start the workshop on your own](../self_paced/).
+{{% /notice %}}
+
+{{% children %}}

--- a/content/prerequisites/aws_event/portal.md
+++ b/content/prerequisites/aws_event/portal.md
@@ -1,0 +1,32 @@
+---
+title: "AWS Workshop Portal"
+chapter: false
+weight: 20
+---
+
+### Login to AWS Workshop Portal
+
+This workshop creates an AWS acccount and a Cloud9 environment. You will need the **Participant Hash** provided upon entry, and your email address to track your unique session.
+
+Connect to the portal by clicking the button or browsing to [https://portal.awsworkshop.io/](https://portal.awsworkshop.io/).
+
+<a
+  href="https://portal.awsworkshop.io/"
+target="_blank" class="btn btn-default">
+Connect to Portal
+<i class="fas fa-sign-in-alt"></i>
+</a>
+
+![Portal Login](/images/portal_login.png)
+
+Enter your **Participant Hash** and your email address, and click **Log In**.
+
+Once you have been logged in, please first log into the AWS console by clicking on the <i class="fas fa-terminal"></i> button. Once you have successfully logged into the AWS Console, you can open the Cloud9 IDE by clicking on the <i class="fas fa-desktop"></i> button.
+
+![Portal Buttons](/images/portal_buttons.png)
+
+{{% notice note %}}
+The workshop added an IAM role for performing all the steps of the workshop in the Cloud9 Environment. You do not need to add a role to the instance powering the Cloud9 Environment.
+{{% /notice %}}
+
+Once you have completed the step above, you can head straight to [**Create a SSH key section**](/prerequisites/sshkey/)

--- a/content/prerequisites/k8stools.md
+++ b/content/prerequisites/k8stools.md
@@ -20,7 +20,7 @@ mkdir -p ~/.kube
 
 #### Install kubectl
 ```
-sudo curl --silent --location -o /usr/local/bin/kubectl "https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/kubectl"
+sudo curl --silent --location -o /usr/local/bin/kubectl "https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/kubectl"
 sudo chmod +x /usr/local/bin/kubectl
 ```
 

--- a/content/prerequisites/self_paced/_index.md
+++ b/content/prerequisites/self_paced/_index.md
@@ -1,0 +1,13 @@
+---
+title: "...on your own"
+chapter: true
+weight: 11
+---
+
+### Running the workshop on your own
+
+{{% notice warning %}}
+Only complete this section if you are running the workshop on your own. If you are at an AWS hosted event (such as re:Invent, Kubecon, Immersion Day, etc), go to [Start the workshop at an AWS event](../aws_event/).
+{{% /notice %}}
+
+{{% children %}}

--- a/content/prerequisites/self_paced/account.md
+++ b/content/prerequisites/self_paced/account.md
@@ -1,0 +1,28 @@
+---
+title: "Create an AWS account"
+chapter: false
+weight: 1
+---
+
+{{% notice warning %}}
+Your account must have the ability to create new IAM roles and scope other IAM permissions.
+{{% /notice %}}
+
+1. If you don't already have an AWS account with Administrator access: [create
+one now by clicking here](https://aws.amazon.com/getting-started/)
+
+1. Once you have an AWS account, ensure you are following the remaining workshop steps
+as an IAM user with administrator access to the AWS account:
+[Create a new IAM user to use for the workshop](https://console.aws.amazon.com/iam/home?#/users$new)
+
+1. Enter the user details:
+![Create User](/images/iam-1-create-user.png)
+
+1. Attach the AdministratorAccess IAM Policy:
+![Attach Policy](/images/iam-2-attach-policy.png)
+
+1. Click to create the new user:
+![Confirm User](/images/iam-3-create-user.png)
+
+1. Take note of the login URL and save:
+![Login URL](/images/iam-4-save-url.png)

--- a/content/prerequisites/self_paced/ec2instance.md
+++ b/content/prerequisites/self_paced/ec2instance.md
@@ -1,0 +1,11 @@
+---
+title: "Attach the IAM role to your Workspace"
+chapter: false
+weight: 26
+---
+
+1. Follow [this deep link to find your Cloud9 EC2 instance](https://console.aws.amazon.com/ec2/v2/home?#Instances:tag:Name=aws-cloud9-eksworkshop*;sort=desc:launchTime)
+1. Select the instance, then choose **Actions / Instance Settings / Attach/Replace IAM Role**
+![c9instancerole](/images/c9instancerole.png)
+1. Choose **eksworkshop-admin** from the **IAM Role** drop down, and select **Apply**
+![c9attachrole](/images/c9attachrole.png)

--- a/content/prerequisites/self_paced/eu-west-1.md
+++ b/content/prerequisites/self_paced/eu-west-1.md
@@ -1,0 +1,8 @@
+---
+title: "Ireland"
+chapter: false
+disableToc: true
+hidden: true
+---
+
+Create a Cloud9 Environment: [https://eu-west-1.console.aws.amazon.com/cloud9/home?region=eu-west-1](https://eu-west-1.console.aws.amazon.com/cloud9/home?region=eu-west-1)

--- a/content/prerequisites/self_paced/iamrole.md
+++ b/content/prerequisites/self_paced/iamrole.md
@@ -1,0 +1,12 @@
+---
+title: "Create an IAM role for your Workspace"
+chapter: false
+weight: 25
+---
+
+
+1. Follow [this deep link to create an IAM role with Administrator access.](https://console.aws.amazon.com/iam/home#/roles$new?step=review&commonUseCase=EC2%2BEC2&selectedUseCase=EC2&policies=arn:aws:iam::aws:policy%2FAdministratorAccess)
+1. Confirm that **AWS service** and **EC2** are selected, then click **Next** to view permissions.
+1. Confirm that **AdministratorAccess** is checked, then click **Next** to review.
+1. Enter **eksworkshop-admin** for the Name, and select **Create Role**
+![createrole](/images/createrole.png)

--- a/content/prerequisites/self_paced/us-east-2.md
+++ b/content/prerequisites/self_paced/us-east-2.md
@@ -1,0 +1,8 @@
+---
+title: "Ohio"
+chapter: false
+disableToc: true
+hidden: true
+---
+
+Create a Cloud9 Environment: [https://us-east-2.console.aws.amazon.com/cloud9/home?region=us-east-2](https://us-east-2.console.aws.amazon.com/cloud9/home?region=us-east-2)

--- a/content/prerequisites/self_paced/us-west-2.md
+++ b/content/prerequisites/self_paced/us-west-2.md
@@ -1,0 +1,8 @@
+---
+title: "Oregon"
+chapter: false
+disableToc: true
+hidden: true
+---
+
+Create a Cloud9 Environment: [https://us-west-2.console.aws.amazon.com/cloud9/home?region=us-west-2](https://us-west-2.console.aws.amazon.com/cloud9/home?region=us-west-2)

--- a/content/prerequisites/self_paced/workspace.md
+++ b/content/prerequisites/self_paced/workspace.md
@@ -1,0 +1,43 @@
+---
+title: "Create a Workspace"
+chapter: false
+weight: 10
+---
+
+{{% notice warning %}}
+The Cloud9 workspace should be built by an IAM user with Administrator privileges,
+not the root account user. Please ensure you are logged in as an IAM user, not the root
+account user.
+{{% /notice %}}
+
+<!---
+{{% notice info %}}
+This workshop was designed to run in the **Oregon (us-west-2)** region. **Please don't
+run in any other region.** Future versions of this workshop will expand region availability,
+and this message will be removed.
+{{% /notice %}}
+-->
+
+{{% notice tip %}}
+Ad blockers, javascript disablers, and tracking blockers should be disabled for
+the cloud9 domain, or connecting to the workspace might be impacted.
+{{% /notice %}}
+
+### Launch Cloud9 in your closest region:
+{{< tabs name="Region" >}}
+{{{< tab name="Oregon" include="us-west-2.md" />}}
+{{{< tab name="Ohio" include="us-east-2.md" />}}
+{{{< tab name="Ireland" include="eu-west-1.md" />}}
+{{< /tabs >}}
+
+- Select **Create environment**
+- Name it **eksworkshop**, and take all other defaults
+- When it comes up, customize the environment by closing the **welcome tab**
+and **lower work area**, and opening a new **terminal** tab in the main work area:
+![c9before](/images/c9before.png)
+
+- Your workspace should now look like this:
+![c9after](/images/c9after.png)
+
+- If you like this theme, you can choose it yourself by selecting **View / Themes / Solarized / Solarized Dark**
+in the Cloud9 workspace menu.

--- a/content/prerequisites/sshkey.md
+++ b/content/prerequisites/sshkey.md
@@ -4,6 +4,12 @@ chapter: false
 weight: 21
 ---
 
+{{% notice info %}}
+Starting from here, when you see command to be entered such as below, you will enter these commands into Cloud9 IDE. You can use the **Copy to clipboard** feature (right hand upper corner) to simply copy and paste into Cloud9. In order to paste, you can use Ctrl + V for Windows or Command + V for Mac.
+{{% /notice %}}
+
+Please run this command to generate SSH Key in Cloud9. This key will be used on the worker node instances to allow ssh access if necessary.
+
 ```
 
 ssh-keygen
@@ -13,8 +19,6 @@ ssh-keygen
 {{% notice tip %}}
 Press `enter` 3 times to take the default choices
 {{% /notice %}}
-
-This key will be used on the worker node instances to allow ssh access if necessary.
 
 <!---
 removing below because we are only using eksctl now, and it handles the key automatically

--- a/content/prerequisites/workspaceiam.md
+++ b/content/prerequisites/workspaceiam.md
@@ -28,3 +28,49 @@ echo "export AWS_REGION=${AWS_REGION}" >> ~/.bash_profile
 aws configure set default.region ${AWS_REGION}
 aws configure get default.region
 ```
+
+### Validate the IAM role
+
+Use the [GetCallerIdentity](https://docs.aws.amazon.com/cli/latest/reference/sts/get-caller-identity.html) CLI command to validate that the Cloud9 IDE is using the correct IAM role.
+
+First, get the IAM role name from the AWS CLI.
+```bash
+INSTANCE_PROFILE_NAME=`basename $(aws ec2 describe-instances --filters Name=tag:Name,Values=aws-cloud9-${C9_PROJECT}-${C9_PID} | jq -r '.Reservations[0].Instances[0].IamInstanceProfile.Arn' | awk -F "/" "{print $2}")`
+aws iam get-instance-profile --instance-profile-name $INSTANCE_PROFILE_NAME --query "InstanceProfile.Roles[0].RoleName" --output text
+```
+
+The output is the role name.
+
+```output
+modernizer-workshop-cl9
+```
+
+Compare that with the result of
+
+```bash
+aws sts get-caller-identity
+```
+
+#### VALID
+
+If the _Arn_ contains the role name from above and an Instance ID, you may proceed.
+
+```output
+{
+    "Account": "123456789012", 
+    "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef", 
+    "Arn": "arn:aws:sts::123456789012:assumed-role/modernizer-workshop-cl9/i-01234567890abcdef"
+}
+```
+
+#### INVALID
+
+If the _Arn contains `TeamRole`, `MasterRole`, or does not match the role name, <span style="color: red;">**DO NOT PROCEED**</span>. Go back and confirm the steps on this page.
+
+```output
+{
+    "Account": "123456789012", 
+    "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef", 
+    "Arn": "arn:aws:sts::123456789012:assumed-role/TeamRole/MasterRole"
+}
+```

--- a/content/securecloud/backend-policy.md
+++ b/content/securecloud/backend-policy.md
@@ -3,63 +3,51 @@ title: "Policy Enabling the Backends"
 weight: 210
 ---
 
-Now, let's create a policy that allows the _ecsdemo-frontend_ microservice to
-communicate with the _ecsdemo-nodejs_ microservice:
+Now, let's create a policy that allows the _ecsdemo-frontend_ microservice to communicate with the _ecsdemo-nodejs_ microservice. That policy will look something like this:
 
 ```
-cat <<EoF > ~/environment/ecsdemo-nodejs-policy.yaml
-apiVersion: projectcalico.org/v3
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: ecsdemo-nodejs
 spec:
-  selector: app == 'ecsdemo-nodejs'
-  types:
-  - Ingress
-  ingress:
-  - action: Allow
-    protocol: TCP
-    source:
-      selector: app == 'ecsdemo-frontend'
-    destination:
-      ports:
-      - 3000
-EoF
-```
-
-We can load it into Kubernetes using kubectl:
+  podSelector:
+    matchLabels:
+      app: ecsdemo-nodejs
+ingress:
+- ports:
+  -port: 3000
+  from:
+  - podSelector:
+    matchLabels:
+      app: ecsdemo-frontend
 
 ```
-$ kubectl apply -f ~/environment/ecsdemo-nodejs-policy.yaml
-```
 
-Once you've done that, again, look at the flow logs and you will see that traffic
-between the frontend and the nodejs services is now being allowed, but the traffic
-from the frontend to the crystal microservice is still being blocked.  Let's fix that.
+Let's create that policy in a file, called _ecsdemo-nodejs-policy.yaml_ and then load it into Kubernetes using kubectl.
 
 ```
-cat <<EoF > ~/environment/ecsdemo-crystal-policy.yaml
-apiVersion: projectcalico.org/v3
+$ kubectl apply -f ecsdemo-nodejs-policy.yaml
+```
+
+Once you've done that, again, look at the flow logs and you will see that traffic between the frontend and the nodejs services is now being allowed, but the traffic from the frontend to the crystal microservice is still being blocked.  Let's fix that.
+
+```
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: ecsdemo-crystal
 spec:
-  selector: app == 'ecsdemo-crystal'
-  types:
-  - Ingress
-  ingress:
-  - action: Allow
-    protocol: TCP
-    source:
-      selector: app == 'ecsdemo-frontend'
-    destination:
-      ports:
-      - 3000
-EoF
+  podSelector:
+    matchLabels:
+      app: ecsdemo-crystal
+ingress:
+- ports:
+  -port: 3000
+  from:
+  - podSelector:
+    matchLabels:
+      app: ecsdemo-frontend
 ```
 
-Use kubectl to apply the new policy, and now you will see that all the frontend
-to backend traffic is now being allowed again.
-```
-$ kubectl apply -f ~/environment/ecsdemo-crystal-policy.yaml
-```
+Use the same file create and kubectl apply steps that we used above to apply this new policy, and now you will see that all the frontend to backend traffic is now being allowed, again.

--- a/content/securecloud/environment.md
+++ b/content/securecloud/environment.md
@@ -2,44 +2,42 @@
 title: "Preparing the environment"
 weight: 20
 ---
-#### There are some prerequisites that are necessary for Tigera Secure Cloud Edition to function.
-Your workshop Kubernetes cluster already meets the following specifications:
 
-* Exists in a single VPC.
-* Has the Kubernetes AWS cloud provider enabled.
-* Networking provider is Amazon VPC Networking
+{{% notice info %}}
+If you have setup your kubernetes cluster using the Cloud9 environment and eksctl, as instructed at the start of this workshop, then you can follow the abbreviated instructions here, as much of the work has been done for you.  If not please refer to the instructions you received when you downloaded the _Tigera Secure Cloud Edition 1.0.1_ link.
+{{% /notice %}}
 
-#### Your Cloud9 workspace already meets the software requirements as well:
+{{% notice tip %}}
+The instructions below assume that you have followed all of the initial _EKSWorkshop_ setup instructions when creating your cluster.  If you have not, some of the commands or environment settings that we rely on below will not be set correctly.  If you encounter problems, please check your initial setup and/or consult the instructions mentioned above.
+{{% /notice %}}
 
-* kubectl: configured to access the cluster.
-* AWS Command Line Interface (CLI): The following commands are known to work well with AWS CLI 1.15.40
-* jq
+First, you need to install tsctl in your Cloud9 environment.
 
-Now let's set some environment variables to use in our commands: If you used
-_eksctl_ to install your cluster, then the following commands should set up
-everything for you:
 ```
-VPC_ID=$(aws eks describe-cluster --name eksworkshop-eksctl --query 'cluster.resourcesVpcConfig.vpcId' --output text)
-K8S_NODE_SGS=$(aws ec2 describe-security-groups --filters Name=tag:aws:cloudformation:logical-id,Values=NodeSecurityGroup Name=vpc-id,Values=${VPC_ID} --query "SecurityGroups[0].GroupId" --output text)
+sudo curl --location -o /usr/local/bin/tsctl https://s3.amazonaws.com/tigera-public/ce/v1.0.6/tsctl-linux-amd64
+sudo chmod +x /usr/local/bin/tsctl
+```
+
+Next, you will need to set some environment variables.  There are commands for some of them, but a few you need to supply.
+
+The $CLUSTER_NAME variable is the same that you used to create the cluster using the 'eksctl' command at the beginning of the workshop.  If you followed the directions, it will be 'eksworkshop-eksctl'
+
+```
+CLUSTER_NAME=eksworkshop-eksctl
+```
+
+The next thing we need to manually set is your Tigera Secure Cloud Edition $TS_TOKEN.  This can be found by checking your [Zendesk tickets](https://support.tigera.io/hc/en-us/requests).  The Token can be found in your welcome ticket and is a _UUID_, or long string of hex digits.
+
+```
+TS_TOKEN=<token UUID>
+```
+
+The following commands will set the remainder of the environment variables.
+
+```
+VPC_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query 'cluster.resourcesVpcConfig.vpcId' --output text)
+K8S_NODE_SGS=$(aws ec2 describe-security-groups --filters Name=tag:aws:cloudformation:logical-id,Values=SG Name=vpc-id,Values=${VPC_ID} --query "SecurityGroups[0].GroupId" --output text)
 CONTROL_PLANE_SG=$(aws ec2 describe-security-groups --filters Name=tag:aws:cloudformation:logical-id,Values=ControlPlaneSecurityGroup Name=vpc-id,Values=${VPC_ID} --query "SecurityGroups[0].GroupId" --output text)
 ```
 
-If you didn't use _eksctl_ please refer to the instructions in the Tigera Secure CE v1.0.0 download link.
-
-After the environment variables are set, you need to install the _tsctl_ binary on your machine and run it to install Tigera Secure CE on your cluster.
-
-<!---
-If you have a mac:
-```
-curl -o tsctl -O https://s3.amazonaws.com/tigera-public/ce/tsctl-darwin-amd64
-chmod +x tsctl
-```
-
-If you are on a Linux box:
---->
-
-```
-curl -o tsctl -O https://s3.amazonaws.com/tigera-public/ce/tsctl-linux-amd64
-chmod +x tsctl
-sudo mv -v tsctl /usr/local/bin/
-```
+If you have any problems, please make sure that you have setup your Cloud9 environment correctly for the workshop.

--- a/content/securecloud/init-policy.md
+++ b/content/securecloud/init-policy.md
@@ -5,21 +5,20 @@ weight: 200
 
 Now that we've seen that all the traffic is being allowed in the cluster, let's start tightening the policies, and restrict some of the traffic.  To do that, we will first create a _default deny_ policy that will block all inbound traffic in our default namespace unless it is specifically allowed.  To do that, we create a null policy that matches everything in the default namespace.
 
-The YAML that defines such a policy can be seen below:
+The YAML fragment that defines such a policy can be seen below
 
 ```
-cat <<EoF > ~/environment/default-deny.yaml
 kind: NetworkPolicy
-apiVersion: projectcalico.org/v3
+apiVersion: networking.k8s.io/v1
 metadata:
   name: default-deny
 spec:
-  selector:
-EoF
+  podSelector:
+    matchLabels: {}
 ```
 
-We can apply the file called _default-deny.yaml_ with the above contents to your cluster using kubectl:
+Now create a file called _default-deny.yaml_ with the above contents and install it in your cluster using kubectl.
 
 ```
-$ kubectl apply -f ~/environment/default-deny.yaml
+$ kubectl apply -f default-deny.yaml
 ```

--- a/content/securecloud/install.md
+++ b/content/securecloud/install.md
@@ -2,30 +2,19 @@
 title: "Installing Tigera Secure Cloud Edition"
 weight: 30
 ---
-Now that your environment variables are set, and _tsctl_ is installed, go back to
-the instructions in the Tigera Secure CE v1.0.0 download link and look for the second
-step in the **Procedure** section.  It should look something like this:
-
-Copy the text and **edit it** before running it in your workspace.
-**DO NOT SIMPLY COPY/PASTE THE TEXT BELOW** It will not work.  The token is
-unique to each registration.
+Now that your environment variables are set, and _tsctl_ is installed, go back to the instructions in the Tigera Secure CE v1.0.1 download link and look for the second step in the **Procedure** section.  It should look something like this:
 ```
-tsctl install --token <a long hex string goes here> \
+tsctl install --token $TS_TOKEN \
+            --kubeconfig ~/.kube/config \
             --cluster-name $CLUSTER_NAME \
             --vpc-id $VPC_ID \
             --control-plane-sg $CONTROL_PLANE_SG \
             --node-sgs $K8S_NODE_SGS
 ```
+Copy that text and run it in your Cloud9 shell.
 
-{{% notice tip %}}
-It may take up to five seconds for pods to gain network connectivity after starting up.
-{{% /notice %}}
+### Known Issues
 
-<!---
-{{% notice warning %}}
-Network Load Balancers (NLBs) may lose their ability to balance traffic to pods after
-    installing Tigera Secure CE. To resolve this issue, manually modify the pods’ security
-    group to allow ingress traffic from the original source of the traffic (not the NLB).
-    See the User Guide for more information or contact Tigera support for assistance.
-{{% /notice %}}
---->
+* It may take up to five seconds for pods to gain network connectivity after starting up.
+
+* Network Load Balancers (NLBs) may lose their ability to balance traffic to pods after installing Tigera Secure CE. To resolve this issue, manually modify the pods’ security group to allow ingress traffic from the original source of the traffic (not the NLB). See the User Guide for more information or contact Tigera support for assistance.

--- a/content/securecloud/policies/default-deny.yaml
+++ b/content/securecloud/policies/default-deny.yaml
@@ -1,6 +1,7 @@
-kind: NetworkPolicy
-apiVersion: projectcalico.org/v3
+kkind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
 metadata:
   name: default-deny
 spec:
-  selector:
+  podSelector:
+    matchLabels: {}

--- a/content/securecloud/policies/ecsdemo-crystal.yaml
+++ b/content/securecloud/policies/ecsdemo-crystal.yaml
@@ -1,16 +1,15 @@
-apiVersion: projectcalico.org/v3
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: ecsdemo-crystal
 spec:
-  selector: app == 'ecsdemo-crystal'
-  types:
-  - Ingress
-  ingress:
-  - action: Allow
-    protocol: TCP
-    source:
-      selector: app == 'ecsdemo-frontend'
-    destination:
-      ports:
-      - 3000
+  podSelector:
+    matchLabels:
+      app: ecsdemo-crystal
+ingress:
+- ports:
+  -port: 3000
+  from:
+  - podSelector:
+    matchLabels:
+      app: ecsdemo-frontend

--- a/content/securecloud/policies/ecsdemo-nodejs.yaml
+++ b/content/securecloud/policies/ecsdemo-nodejs.yaml
@@ -1,16 +1,15 @@
-apiVersion: projectcalico.org/v3
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: ecsdemo-nodejs
 spec:
-  selector: app == 'ecsdemo-nodejs'
-  types:
-  - Ingress
-  ingress:
-  - action: Allow
-    protocol: TCP
-    source:
-      selector: app == 'ecsdemo-frontend'
-    destination:
-      ports:
-      - 3000
+  podSelector:
+    matchLabels:
+      app: ecsdemo-nodejs
+ingress:
+- ports:
+  -port: 3000
+  from:
+  - podSelector:
+    matchLabels:
+      app: ecsdemo-frontend

--- a/content/securecloud/register.md
+++ b/content/securecloud/register.md
@@ -3,19 +3,14 @@ title: "Register"
 date: 2018-08-07T13:15:13-07:00
 weight: 10
 ---
-[Tigera Secure Cloud Edition](https://www.tigera.io/tigera-secure-ce) can be enabled through the [AWS Marketplace].
- However, for this workshop, Tigera has enabled a 30 day free trial.  To register for
- the free trial, please follow the steps below:
+[Tigera Secure Cloud Edition](https://www.tigera.io/tigera-secure-ce) can be enabled through the [AWS Marketplace].  However, for this workshop, Tigera has enabled a 30 day free trial.  To register for the free trial, please follow the steps below:
 
 - Go to the Tigera Secure Cloud Edition trial registration website at https://ce.tigera.io and click the *register* button.
+
 - On the next page fill in your e-mail and company name and use the code **EKS30** for the access code.
-- Wait for a few minutes for a confirmation e-mail to arrive in your inbox.
-- Click on the link in the e-mail and you will be directed to the Tigera support web portal.
-  Create a new password and log into the Tigera Support web portal (you will
-  automatically be directed there).  You can come back to the [support page](https://support.tigera.io)
-  in the future by using your login and password.
-- Once on the support site, you will have an option to *download software*.  Continue
-  to follow the links until you are prompted to download ANX v1.0.0.  When you click on
-  that link, you will be presented with a webpage with instructions to install Tigera
-  Secure Cloud Edition on your cluster.  Save that page, as you will need to refer to those
-  instructions in the next step.
+
+- Wait for a few minutes for a confirmation e-mail to arrive in your inbox.  
+
+- Click on the link in the e-mail and you will be directed to the Tigera support web portal.  Create a new password and log into the Tigera Support web portal (you will automatically be directed there).  You can come back to the [support page](https://support.tigera.io) in the future by using your login and password.
+
+- Once on the support site, you will have an option to *download software*.  Continue to follow the links until you are prompted to Download _Tigera Secure Cloud Edition v1.0.1_.  When you click on that link, you will be presented with a webpage with instructions to install Tigera Secure Cloud Edition on your cluster.  Save that page, as you will need to refer to those instructions in the next step.

--- a/package.json
+++ b/package.json
@@ -1,28 +1,31 @@
 {
-	"name": "eksworkshop",
-	"version": "1.0.0",
-	"homepage": "https://github.com/brentley/eksworkshop#readme",
-	"bugs": {
-		"url": "https://github.com/brentley/eksworkshop/issues"
-	},
-	"license": "ISC",
-	"main": "index.js",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/brentley/eksworkshop.git"
-	},
-	"scripts": {
-		"drafts": "hugo server -w -v -DF --disableFastRender --enableGitInfo --bind=0.0.0.0",
-		"server": "hugo server -w -v --enableGitInfo --bind=0.0.0.0",
-		"build": "hugo -v",
-		"test": "docker run -v $PWD/public/:/public 18fgsa/html-proofer /public --empty-alt-ignore --allow-hash-href",
-		"deploy": "aws s3 sync public/ s3://us-east-1-eksworkshop.com/ --delete",
-		"deploycontent": "aws s3 sync public/ s3://us-east-1-eksworkshop.com/ --delete --cache-control \"max-age=3600, public\" --exclude \"*\" --include \"*.html\" --include \"*.xml\"",
-		"deployothers": "aws s3 sync public/ s3://us-east-1-eksworkshop.com/ --delete --cache-control \"max-age=86400, public\" --exclude \"*.html\" --exclude \"*.xml\""
-	},
-	"dependencies": {
-		"@fortawesome/fontawesome-free": "^5.3.1",
-		"hugo-cli": "0.7.0",
-		"hugo-lunr": "0.0.4"
-	}
+  "name": "eksworkshop",
+  "version": "1.0.0",
+  "homepage": "https://github.com/aws-samples/eks-workshop#readme",
+  "bugs": {
+    "url": "https://github.com/aws-samples/eks-workshop/issues"
+  },
+  "license": "ISC",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aws-samples/eks-workshop.git"
+  },
+  "scripts": {
+    "theme": "git submodule init && git submodule update",
+    "drafts": "hugo server -w -v -DF --disableFastRender --enableGitInfo --bind=0.0.0.0",
+    "server": "hugo server -w -v --enableGitInfo --bind=0.0.0.0 --port 8080 --navigateToChanged",
+    "build": "hugo -v",
+    "test": "docker run -v $PWD/public/:/public 18fgsa/html-proofer /public --empty-alt-ignore --allow-hash-href --log-level ':debug'",
+    "deploy": "aws s3 sync public/ s3://us-east-1-eksworkshop.com/ --delete",
+    "deploycontent": "aws s3 sync public/ s3://us-east-1-eksworkshop.com/ --delete --cache-control \"max-age=3600, public\" --exclude \"*\" --include \"*.html\" --include \"*.xml\"",
+    "deploytemplates": "aws s3 sync templates/ s3://${TEMPLATE_BUCKET}/templates/${CODEBUILD_GIT_CLEAN_BRANCH}/ --delete --acl public-read --cache-control \"max-age=86400, public\"",
+    "deployothers": "aws s3 sync public/ s3://us-east-1-eksworkshop.com/ --delete --cache-control \"max-age=86400, public\" --exclude \"*.html\" --exclude \"*.xml\""
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.5.0",
+    "hugo-cli": "^0.7.0",
+    "hugo-lunr": "0.0.4",
+    "mermaid": "^8.0.0-rc.8"
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I've updated the TSCE install instructions for version 1.0.1 and the cloud9 environment.  I have also backported a few other install instructions (eksctl and k8stools) that had the incorrect versioning.

This should fix eksworkshop.com/tigera - we need to do more to fully show TSCE in the master branch - but this at least gets the tigera branch working again.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
