### PR TITLE
Add a third-party-cookie link

### DIFF
--- a/content/prerequisites/self_paced/workspace.md
+++ b/content/prerequisites/self_paced/workspace.md
@@ -21,6 +21,7 @@ and this message will be removed.
 {{% notice tip %}}
 Ad blockers, javascript disablers, and tracking blockers should be disabled for
 the cloud9 domain, or connecting to the workspace might be impacted.
+Cloud9 requires third-party-cookies. You can whitelist the [specific domains]( https://docs.aws.amazon.com/cloud9/latest/user-guide/troubleshooting.html#troubleshooting-env-loading).
 {{% /notice %}}
 
 ### Launch Cloud9 in your closest region:


### PR DESCRIPTION
Cloud9 requires third-party-cookies. Many people might want to disable them globally. So, it is beneficial to provide a link to the documentation for the specific domains to whitelist. This will probably prevent some questions and save time searching for them every time, thus providing a better overall experience.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
