### PR TITLE
Update customize.md

### DIFF
--- a/content/helm_root/helm_micro/customize.md
+++ b/content/helm_root/helm_micro/customize.md
@@ -80,7 +80,7 @@ cat <<EoF > ~/environment/eksdemo/values.yaml
 # Declare variables to be passed into your templates.
 
 # Release-wide Values
-replica: 3
+replicas: 3
 version: 'latest'
 
 # Service Specific Values


### PR DESCRIPTION
The values.yaml file uses the key `replica` instead of `replicas`. This causes the template value of 3 to not be inserted into the deployments. I don't know if this was intentional, since the next page in the tutorial asks the user to verify the dry-run output is correct. But since that page doesn't call out the omission, I figured it was unintentional and should probably be corrected here (or perhaps better to be called out on the next page).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
