### PR TITLE
Use quotes for jq stacks

### DIFF
--- a/content/eksctl/test.md
+++ b/content/eksctl/test.md
@@ -13,7 +13,7 @@ kubectl get nodes
 Export the Worker Role Name for use throughout the workshop
 
 ```bash
-INSTANCE_PROFILE_PREFIX=$(aws cloudformation describe-stacks | jq -r .Stacks[].StackName | grep eksctl-eksworkshop-eksctl-nodegroup)
+INSTANCE_PROFILE_PREFIX=$(aws cloudformation describe-stacks | jq -r '.Stacks[].StackName' | grep eksctl-eksworkshop-eksctl-nodegroup)
 INSTANCE_PROFILE_NAME=$(aws iam list-instance-profiles | jq -r '.InstanceProfiles[].InstanceProfileName' | grep $INSTANCE_PROFILE_PREFIX)
 ROLE_NAME=$(aws iam get-instance-profile --instance-profile-name $INSTANCE_PROFILE_NAME | jq -r '.InstanceProfile.Roles[] | .RoleName')
 echo "export ROLE_NAME=${ROLE_NAME}" >> ~/.bash_profile


### PR DESCRIPTION
If we don't use quotes it fails
```
➜  eksworkshop aws cloudformation describe-stacks | jq -r .Stacks[].StackName
zsh: no matches found: .Stacks[].StackName
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
```