### PR TITLE
Spelling error fixed

### DIFF
--- a/content/spotworkers/workers.md
+++ b/content/spotworkers/workers.md
@@ -101,6 +101,6 @@ kubectl get nodes --show-labels --selector=lifecycle=OnDemand
 
 ![OnDemand Output](/images/spotworkers/spot_get_od.png)
 
-You can use the `kubectl describe nodes` with one of the spot nodes to see the taints aaplied to the EC2 Spot Instances.
+You can use the `kubectl describe nodes` with one of the spot nodes to see the taints applied to the EC2 Spot Instances.
 
 ![Spot Taints](/images/spotworkers/instance_taints.png)


### PR DESCRIPTION
use to read "aaplied" and changed to "applied"

*Issue #, if available:*

*Description of changes:*
use to read "aaplied" and changed to "applied"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
