### PR TITLE
Updated command because it was not working

### DIFF
--- a/content/x-ray/role.md
+++ b/content/x-ray/role.md
@@ -10,7 +10,7 @@ In order for the [X-Ray daemon](https://docs.aws.amazon.com/xray/latest/devguide
 Modify the role in the Cloud9 terminal:
 
 ```
-PROFILE=$(aws ec2 describe-instances --filters --filters Name=tag:Name,Values=eksworkshop-eksctl-0-Node --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
+PROFILE=$(aws ec2 describe-instances --filters --filters Name=tag:Name,Values=eksworkshop-eksctl-ng* --query 'Reservations[0].Instances[0].IamInstanceProfile.Arn' --output text | cut -d '/' -f 2)
 
 ROLE=$(aws iam get-instance-profile --instance-profile-name $PROFILE --query "InstanceProfile.Roles[0].RoleName" --output text)
 


### PR DESCRIPTION
When following the workshop, the NAME tag of the instances has the format "eksworkshop-eksctl-ng-85b144bf-Node" and the "aws iam attach-role-policy" command won't work since the $ROLE has the value of "None"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
