### PR TITLE
Update IAM role name in documentation

### DIFF
--- a/content/prerequisites/workspaceiam.md
+++ b/content/prerequisites/workspaceiam.md
@@ -42,7 +42,7 @@ aws iam get-instance-profile --instance-profile-name $INSTANCE_PROFILE_NAME --qu
 The output is the role name.
 
 ```output
-modernizer-workshop-cl9
+eksworkshop-admin
 ```
 
 Compare that with the result of
@@ -59,7 +59,7 @@ If the _Arn_ contains the role name from above and an Instance ID, you may proce
 {
     "Account": "123456789012", 
     "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef", 
-    "Arn": "arn:aws:sts::123456789012:assumed-role/modernizer-workshop-cl9/i-01234567890abcdef"
+    "Arn": "arn:aws:sts::123456789012:assumed-role/eksworkshop-admin/i-01234567890abcdef"
 }
 ```
 


### PR DESCRIPTION
The documentation mentions creating a role called "eksworkshop-admin" and the verification step later mentions modernizer-admin-cl9 which is confusing (to me)

*Issue #, if available:*

*Description of changes:* Changed modernizer-admin-cl9 to eksworkshop-admin twice in the documentation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
