### PR TITLE
Cloud9 Singapore

### DIFF
--- a/content/prerequisites/self_paced/ap-southeast-1.md
+++ b/content/prerequisites/self_paced/ap-southeast-1.md
@@ -1,0 +1,8 @@
+---
+title: "Singapore"
+chapter: false
+disableToc: true
+hidden: true
+---
+
+Create a Cloud9 Environment: [https://ap-southeast-1.console.aws.amazon.com/cloud9/home?region=ap-southeast-1](https://ap-southeast-1.console.aws.amazon.com/cloud9/home?region=ap-southeast-1)

--- a/content/prerequisites/self_paced/workspace.md
+++ b/content/prerequisites/self_paced/workspace.md
@@ -29,6 +29,7 @@ Cloud9 requires third-party-cookies. You can whitelist the [specific domains]( h
 {{{< tab name="Ireland" include="eu-west-1.md" />}}
 {{{< tab name="Ohio" include="us-east-2.md" />}}
 {{{< tab name="Oregon" include="us-west-2.md" />}}
+{{{< tab name="Singapore" include="ap-southeast-1.md" />}}
 {{< /tabs >}}
 
 - Select **Create environment**

--- a/content/prerequisites/self_paced/workspace.md
+++ b/content/prerequisites/self_paced/workspace.md
@@ -26,9 +26,9 @@ Cloud9 requires third-party-cookies. You can whitelist the [specific domains]( h
 
 ### Launch Cloud9 in your closest region:
 {{< tabs name="Region" >}}
-{{{< tab name="Oregon" include="us-west-2.md" />}}
-{{{< tab name="Ohio" include="us-east-2.md" />}}
 {{{< tab name="Ireland" include="eu-west-1.md" />}}
+{{{< tab name="Ohio" include="us-east-2.md" />}}
+{{{< tab name="Oregon" include="us-west-2.md" />}}
 {{< /tabs >}}
 
 - Select **Create environment**


### PR DESCRIPTION
Lexical sort of region list, added Singapore option for Cloud9.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.