### PR TITLE
update helm install jenkins command

### DIFF
--- a/content/jenkins/deploy.md
+++ b/content/jenkins/deploy.md
@@ -16,7 +16,7 @@ manage the drift as you need to update releases
 #### Install Jenkins
 
 ```
-helm install stable/jenkins --set rbac.install=true --name cicd
+helm install stable/jenkins --set rbac.create=true --name cicd
 ```
 
 The output of this command will give you some additional information such as the


### PR DESCRIPTION
Jenkins helm chart updated 
It's called 'rbac.create' now (instead if 'rbac.install')
It's also enabled by default

*Issue #, if available:*

*Description of changes:*

Changed helm command for installing Jenkins on EKS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
