### PR TITLE
Change apiVersion for EKSCTL input file

### DIFF
--- a/content/eksctl/launcheks.files/eksworkshop.yml.template
+++ b/content/eksctl/launcheks.files/eksworkshop.yml.template
@@ -5,7 +5,7 @@
 # For more examples, see: https://github.com/weaveworks/eksctl/blob/master/examples
 #################################################
 
-apiVersion: eksctl.io/v1alpha4
+apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 metadata:
   name: eksworkshop-eksctl


### PR DESCRIPTION
*Issue #355* 
https://github.com/aws-samples/eks-workshop/issues/335

*Description of changes:*
Changing the apiVersion to v5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
