### PR TITLE
Update curl to hit HTTP port

### DIFF
--- a/content/exposing_service/exposing.md
+++ b/content/exposing_service/exposing.md
@@ -29,7 +29,7 @@ my-nginx   LoadBalancer   10.100.225.196   aca434079a4cb0a9961170c1-23367063.us-
 ```
 Now, let's try if it's accesible. The ELB can take a couple of minutes in being available on the DNS.
 ```
-curl https://<EXTERNAL-IP> -k
+curl http://<EXTERNAL-IP> -k
 ```
 Output
 ```


### PR DESCRIPTION
*Description of changes:*
The LB is only listening on 80 so the example curl command will not work as is.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
