### PR TITLE
Updated IAM Authenticator install path

### DIFF
--- a/content/prerequisites/k8stools.md
+++ b/content/prerequisites/k8stools.md
@@ -27,7 +27,7 @@ sudo chmod +x /usr/local/bin/kubectl
 
 #### Install AWS IAM Authenticator
 ```
-go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator
+go get -u -v sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator
 sudo mv ~/go/bin/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
 ```
 


### PR DESCRIPTION
Updated link from 

https://github.com/kubernetes-sigs/aws-iam-authenticator/blob/master/README.md#4-set-up-kubectl-to-use-authentication-tokens-provided-by-aws-iam-authenticator-for-kubernetes

*Issue #363*

*Description of changes:*

updated link from

> github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticators

to 

> sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator