### PR TITLE
updating commands to remove aws-iam-authenticator and use aws-cli ins…

### DIFF
--- a/content/dashboard/connect.md
+++ b/content/dashboard/connect.md
@@ -15,7 +15,7 @@ Now we can access the Kubernetes Dashboard
 
 Open a New Terminal Tab  and enter
 ```
-aws-iam-authenticator token -i eksworkshop-eksctl --token-only
+aws eks get-token --cluster-name eksworkshop-eksctl | jq -r '.status.token'
 ```
 
 Copy the output of this command and then *click* the radio button next to

--- a/content/eksctl/launcheks.md
+++ b/content/eksctl/launcheks.md
@@ -13,19 +13,19 @@ weight: 20
 **How do I check the IAM role on the workspace?**
 
 {{%expand "Expand here to see the solution" %}}
-Run `aws sts get-caller-identity` and validate that your _Arn_ contains `eksworkshop-admin` or `TeamRole` 
+Run `aws sts get-caller-identity` and validate that your _Arn_ contains `eksworkshop-admin` or `TeamRole`
 (or the role created when starting the workshop) and an Instance Id.
 
 ```output
 {
-    "Account": "123456789012", 
-    "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef", 
+    "Account": "123456789012",
+    "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef",
     "Arn": "arn:aws:sts::123456789012:assumed-role/eksworkshop-admin/i-01234567890abcdef"
 }
 or
 {
-    "Account": "123456789012", 
-    "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef", 
+    "Account": "123456789012",
+    "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef",
     "Arn": "arn:aws:sts::123456789012:assumed-role/TeamRole/i-01234567890abcdef"
 }
 ```
@@ -58,7 +58,12 @@ eksctl create cluster --name=eksworkshop-eksctl --nodes=3 --node-ami=auto --regi
 {{< /tabs >}}
 
 
-```
+{{% notice note %}}
+If you see this error in the output, it can be safely ignored. We will fix
+it next:
+`[✖] neither aws-iam-authenticator nor heptio-authenticator-aws are installed`
+{{% /notice %}}
+
 {{% notice info %}}
 Launching EKS and all the dependencies will take approximately 15 minutes
 {{% /notice %}}

--- a/content/eksctl/test.md
+++ b/content/eksctl/test.md
@@ -4,6 +4,36 @@ date: 2018-08-07T13:36:57-07:00
 weight: 30
 ---
 
+#### Configure IAM authentication for the cluster:
+You will likely see an error in the output similar to this:
+```
+[✖]  neither aws-iam-authenticator nor heptio-authenticator-aws are installed
+[ℹ]  cluster should be functional despite missing (or misconfigured) client binaries
+[✔]  EKS cluster "eksworkshop-eksctl" in "us-east-2" region is ready
+```
+
+This is caused by eksctl wanting to use aws-iam-authencator to pull IAM tokens.
+As of aws-cli version 1.16.156, this token functionality is built in. Let's check
+our aws-cli version:
+```
+aws --version
+```
+
+Your Cloud9 workspace should already have a version late enough to pull IAM tokens.
+
+If you need to update the aws-cli, use this command:
+```
+pip install awscli --upgrade --user
+
+aws --version
+```
+
+We can update our kubectl config file to use the aws-cli for pulling IAM tokens with
+this command:
+```
+aws eks update-kubeconfig --name eksworkshop-eksctl
+```
+
 Confirm your Nodes:
 
 ```bash

--- a/content/eksctl/test.md
+++ b/content/eksctl/test.md
@@ -16,14 +16,14 @@ This is caused by eksctl wanting to use aws-iam-authencator to pull IAM tokens.
 As of aws-cli version 1.16.156, this token functionality is built in. Let's check
 our aws-cli version:
 ```
-aws --version
+aws --version # in Cloud9, the version output should already be higher than 1.16.156
 ```
 
 Your Cloud9 workspace should already have a version late enough to pull IAM tokens.
 
 If you need to update the aws-cli, use this command:
 ```
-pip install awscli --upgrade --user
+pip install awscli --upgrade --user # this updates aws-cli to the latest available version for the user
 
 aws --version
 ```
@@ -31,14 +31,14 @@ aws --version
 We can update our kubectl config file to use the aws-cli for pulling IAM tokens with
 this command:
 ```
-aws eks update-kubeconfig --name eksworkshop-eksctl
+aws eks update-kubeconfig --name eksworkshop-eksctl # this updates kubeconfig to pull iam tokens using aws-cli
 ```
 
 #### Test the cluster:
 Confirm your Nodes:
 
 ```bash
-kubectl get nodes
+kubectl get nodes # if we see our 3 nodes, we know we have authenticated correctly
 ```
 
 Export the Worker Role Name for use throughout the workshop

--- a/content/eksctl/test.md
+++ b/content/eksctl/test.md
@@ -34,6 +34,7 @@ this command:
 aws eks update-kubeconfig --name eksworkshop-eksctl
 ```
 
+#### Test the cluster:
 Confirm your Nodes:
 
 ```bash

--- a/content/prerequisites/k8stools.md
+++ b/content/prerequisites/k8stools.md
@@ -4,7 +4,7 @@ chapter: false
 weight: 22
 ---
 
-Amazon EKS clusters require kubectl and kubelet binaries and the aws-iam-authenticator
+Amazon EKS clusters require kubectl and kubelet binaries and the aws-cli or aws-iam-authenticator
 binary to allow IAM authentication for your Kubernetes cluster.
 
 {{% notice tip %}}

--- a/content/prerequisites/k8stools.md
+++ b/content/prerequisites/k8stools.md
@@ -27,7 +27,7 @@ sudo chmod +x /usr/local/bin/kubectl
 
 #### Install AWS IAM Authenticator
 ```
-go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator
+go get -u -v sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator
 sudo mv ~/go/bin/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
 ```
 

--- a/content/prerequisites/k8stools.md
+++ b/content/prerequisites/k8stools.md
@@ -13,22 +13,11 @@ binaries. If you are running Mac OSX / Windows, please [see the official EKS doc
 for the download links.](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
 {{% /notice %}}
 
-#### Create the default ~/.kube directory for storing kubectl configuration
-```
-mkdir -p ~/.kube
-```
-
 #### Install kubectl
 ```
 sudo curl --silent --location -o /usr/local/bin/kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/kubectl
 
 sudo chmod +x /usr/local/bin/kubectl
-```
-
-#### Install AWS IAM Authenticator
-```
-go get -u -v sigs.k8s.io/aws-iam-authenticator/cmd/aws-iam-authenticator
-sudo mv ~/go/bin/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
 ```
 
 #### Install JQ and envsubst
@@ -38,9 +27,8 @@ sudo yum -y install jq gettext
 
 #### Verify the binaries are in the path and executable
 ```
-for command in kubectl aws-iam-authenticator jq envsubst
+for command in kubectl jq envsubst
   do
     which $command &>/dev/null && echo "$command in path" || echo "$command NOT FOUND"
   done
 ```
-

--- a/content/prerequisites/workspaceiam.md
+++ b/content/prerequisites/workspaceiam.md
@@ -6,7 +6,7 @@ weight: 30
 
 {{% notice info %}}
 Cloud9 normally manages IAM credentials dynamically. This isn't currently compatible with
-the aws-iam-authenticator plugin, so we will disable it and rely on the IAM role instead.
+the EKS IAM authentication, so we will disable it and rely on the IAM role instead.
 {{% /notice %}}
 
 - Return to your workspace and click the sprocket, or launch a new tab to open the Preferences tab


### PR DESCRIPTION
updating commands to remove aws-iam-authenticator and use aws-cli instead
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
