### PR TITLE
Modify Ingress API version in example

### DIFF
--- a/content/exposing_service/ingress.md
+++ b/content/exposing_service/ingress.md
@@ -19,7 +19,7 @@ An Ingress does not expose arbitrary ports or protocols. Exposing services other
 #### The Ingress Resource
 A minimal ingress resource example:
 ```
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: test-ingress


### PR DESCRIPTION
The API version used is not supported on any Kubernetes version currently available in Amazon EKS. Updating to use the `extensions/v1beta1` version that works with supported Kubernetes versions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
