### PR TITLE
Fix Typo

### DIFF
--- a/content/eksctl/test.md
+++ b/content/eksctl/test.md
@@ -12,7 +12,7 @@ You will likely see an error in the output similar to this:
 [✔]  EKS cluster "eksworkshop-eksctl" in "us-east-2" region is ready
 ```
 
-This is caused by eksctl wanting to use aws-iam-authencator to pull IAM tokens.
+This is caused by eksctl wanting to use aws-iam-authenticator to pull IAM tokens.
 As of aws-cli version 1.16.156, this token functionality is built in. Let's check
 our aws-cli version:
 ```


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Fix a typo on the "Test the Cluster" page: "aws-iam-authencator" to "aws-iam-authenticator"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
