### PR TITLE
Update workflow-advanced.md

### DIFF
--- a/content/batch/workflow-advanced.md
+++ b/content/batch/workflow-advanced.md
@@ -23,7 +23,7 @@ spec:
     container:
       image: alpine:latest
       command: ["sh", "-c"]
-      args: ["touch /tmp/message"]
+      args: ["echo '' >> /tmp/message"]
     outputs:
       artifacts:
       - name: chain


### PR DESCRIPTION
Fix error `failed to save outputs: path /tmp/message does not exist (or /tmp/message is empty) in archive /argo/outputs/artifacts/chain.tgz`

*Issue #, if available:*

*Description of changes:*
Instead of touch to create the file echo '' instead

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
