### PR TITLE
fix iam rights for autoscaler

### DIFF
--- a/content/scaling/deploy_ca.md
+++ b/content/scaling/deploy_ca.md
@@ -86,7 +86,8 @@ cat <<EoF > ~/environment/asg_policy/k8s-asg-policy.json
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:SetDesiredCapacity",
-        "autoscaling:TerminateInstanceInAutoScalingGroup"
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
+        "autoscaling:DescribeTags"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
otherwise the pod seems to fail

*Issue #, if available:*

*Description of changes:*
I got this error before:
```
E0813 13:51:33.484133       1 aws_manager.go:148] Failed to regenerate ASG cache: cannot autodiscover ASGs: AccessDenied: User: arn:aws:sts::xxxxxxxxxxxx:assumed-role/ClusterAutoscalerKubernetesRole/2730e1de-ClusterAutoscalerKubernetesRole is not authorized to perform: autoscaling:DescribeTags
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
