### PR TITLE
ecsdemo-crystal -> ecsdemo-frontend

### DIFF
--- a/content/deploy/scalebackend.md
+++ b/content/deploy/scalebackend.md
@@ -13,7 +13,7 @@ kubectl get deployments
 Now let's scale up the backend services:
 ```
 kubectl scale deployment ecsdemo-nodejs --replicas=3
-kubectl scale deployment ecsdemo-crystal --replicas=3
+kubectl scale deployment ecsdemo-frontend --replicas=3
 ```
 Confirm by looking at deployments again:
 ```


### PR DESCRIPTION
Error with ecsdemo-crystal 

```
workshop:~/environment/ecsdemo-frontend (master) $ kubectl scale deployment ecsdemo-crystal --replicas=3
Error from server (NotFound): deployments.extensions "ecsdemo-crystal" not found
```

Success with ecsdemo-frontend

```
workshop:~/environment/ecsdemo-frontend (master) $ kubectl scale deployment ecsdemo-frontend --replicas=3
deployment.extensions/ecsdemo-frontend scaled
```

