### PR TITLE
Fix search clause for Name tag

### DIFF
--- a/content/prerequisites/ec2instance.md
+++ b/content/prerequisites/ec2instance.md
@@ -4,7 +4,7 @@ chapter: false
 weight: 17
 ---
 
-1. Follow [this deep link to find your Cloud9 EC2 instance](https://console.aws.amazon.com/ec2/v2/home?#Instances:tag:Name=aws-cloud9-*workshop*;sort=desc:launchTime)
+1. Follow [this deep link to find your Cloud9 EC2 instance](https://console.aws.amazon.com/ec2/v2/home?#Instances:tag:Name=aws-cloud9-.*workshop.*;sort=desc:launchTime)
 1. Select the instance, then choose **Actions / Instance Settings / Attach/Replace IAM Role**
 ![c9instancerole](/images/c9instancerole.png)
 1. Choose **eksworkshop-admin** from the **IAM Role** drop down, and select **Apply**


### PR DESCRIPTION
The search should use full regex so changed from aws-cloud9-*workshop* to aws-cloud9-.*workshop.*

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
