### PR TITLE
Change exposed port to 80 and add startup time comment

### DIFF
--- a/content/jenkins/deploy.md
+++ b/content/jenkins/deploy.md
@@ -39,5 +39,12 @@ export SERVICE_IP=$(kubectl get svc --namespace default cicd-jenkins --template 
 echo http://$SERVICE_IP/login
 ```
 
-Depending on your environment the AWS loadbalancer health checks may take a few minutes to put the jenkins instances in service and during this time the link above may display a "site unreachable" message. To check if the instances are in service, follow this [deep link](https://console.aws.amazon.com/ec2/v2/home?#LoadBalancers:tag:kubernetes.io/service-name=default/cicd-jenkins;sort=loadBalancerName) to the load balancer console. On the load balancer select the instances tab and ensure that the instance status is listed as "InService" before proceeding to the jenkins login page. 
+{{% notice info %}}
+This service was configured with a [LoadBalancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/) so,
+an [AWS Elastic Load Balancer](https://aws.amazon.com/elasticloadbalancing/) (ELB) is launched by Kubernetes for the service.
+The EXTERNAL-IP column contains a value that ends with "elb.amazonaws.com" - the full value is the DNS address.
+{{% /notice %}}
 
+{{% notice tip %}}
+When the front-end service is first deployed, it can take up to several minutes for the ELB to be created and DNS updated. During this time the link above may display a "site unreachable" message. To check if the instances are in service, follow this [deep link](https://console.aws.amazon.com/ec2/v2/home?#LoadBalancers:tag:kubernetes.io/service-name=default/cicd-jenkins;sort=loadBalancerName) to the load balancer console. On the load balancer select the instances tab and ensure that the instance status is listed as "InService" before proceeding to the jenkins login page. 
+{{% /notice %}}

--- a/content/jenkins/deploy.md
+++ b/content/jenkins/deploy.md
@@ -16,7 +16,7 @@ manage the drift as you need to update releases
 #### Install Jenkins
 
 ```
-helm install stable/jenkins --set rbac.create=true --name cicd
+helm install stable/jenkins --set rbac.create=true,master.servicePort=80 --name cicd
 ```
 
 The output of this command will give you some additional information such as the
@@ -36,5 +36,8 @@ Once this changes to `running` we can get the `load balancer` address.
 
 ```
 export SERVICE_IP=$(kubectl get svc --namespace default cicd-jenkins --template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}")
-echo http://$SERVICE_IP:8080/login
+echo http://$SERVICE_IP/login
 ```
+
+Depending on your environment the AWS loadbalancer health checks may take a few minutes to put the jenkins instances in service and during this time the link above may display a "site unreachable" message. To check if the instances are in service, follow this [deep link](https://console.aws.amazon.com/ec2/v2/home?#LoadBalancers:tag:kubernetes.io/service-name=default/cicd-jenkins;sort=loadBalancerName) to the load balancer console. On the load balancer select the instances tab and ensure that the instance status is listed as "InService" before proceeding to the jenkins login page. 
+


### PR DESCRIPTION
Some corporate networks filter non-standard http ports like 8080. Since all the other examples so far have used port 80 and the jenkins example works just as well with port 80 exposed I am proposing to change the helm install to use port 80 instead of the default 8080. 

Additionally during experimenting with this example I found that it took the load balancer up to 5min to put the cluster nodes in service  while kubectl already reports the load balancer as active. As such suggesting to add a comment regarding that startup time and providing a means to check on the AWS console whether the instances are in service.
