### PR TITLE
Updating URLs to reflect Weave repo changes

### DIFF
--- a/content/weave_flux/cleanup.md
+++ b/content/weave_flux/cleanup.md
@@ -45,8 +45,7 @@ aws iam delete-role --role-name eksworkshop-CodeBuildServiceRole
 
 Remove the artifact bucket you previously created 
 ```
-aws sts get-caller-identity
-ACCT=123456789012
-aws s3 rb s3://eksworkshop-${ACCT}-codepipeline-artifacts --force
+ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
+aws s3 rb s3://eksworkshop-${ACCOUNT_ID}-codepipeline-artifacts --force
 ```
 

--- a/content/weave_flux/codepipeline.md
+++ b/content/weave_flux/codepipeline.md
@@ -53,7 +53,7 @@ echo "# eks-example" > README.md
 mkdir src
 wget -O src/hello.conf https://eksworkshop.com/weave_flux/app.files/hello.conf
 wget -O src/index.html https://eksworkshop.com/weave_flux/app.files/index.html
-wget https://eksworkshop.com/weave_flux/app.files/Dockerfile
+wget https://raw.githubusercontent.com/aws-samples/eks-workshop/master/content/weave_flux/app.files/Dockerfile
 ```
 
 Now that we have a simple hello world app, commit the changes to start the image build pipeline.  

--- a/content/weave_flux/installweaveflux.md
+++ b/content/weave_flux/installweaveflux.md
@@ -10,7 +10,7 @@ Now we will use Helm to install Weave Flux into our cluster and enable it to int
 First, install the Flux Custom Resource Definition:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/weaveworks/flux/master/deploy-helm/flux-helm-release-crd.yaml
+kubectl apply -f https://raw.githubusercontent.com/fluxcd/flux/helm-0.10.1/deploy-helm/flux-helm-release-crd.yaml
 ```
 
 Check that Tiller is installed. 
@@ -30,14 +30,14 @@ Update the Git URL below to match your user name and Kubernetes configuration ma
 {{% /notice %}}
 
 ```
-helm repo add weaveworks https://weaveworks.github.io/flux
+helm repo add fluxcd https://charts.fluxcd.io
 
 helm upgrade -i flux \
 --set helmOperator.create=true \
 --set helmOperator.createCRD=false \
 --set git.url=git@github.com:YOURUSER/k8s-config \
 --namespace flux \
-weaveworks/flux
+fluxcd/flux
 ```
 
 Watch the install and confirm everything starts.  There should be 3 pods.  
@@ -48,7 +48,7 @@ kubectl get pods -n flux
 Install fluxctl in order to get the SSH key to allow GitHub write access.  This allows Flux to keep the configuration in GitHub in sync with the configuration deployed in the cluster.  
 
 ```
-sudo wget -O /usr/local/bin/fluxctl https://github.com/weaveworks/flux/releases/download/1.12.3/fluxctl_linux_amd64
+sudo wget -O /usr/local/bin/fluxctl https://github.com/fluxcd/flux/releases/download/1.14.1/fluxctl_linux_amd64
 sudo chmod 755 /usr/local/bin/fluxctl
 
 fluxctl version

--- a/content/weave_flux/prereqs.md
+++ b/content/weave_flux/prereqs.md
@@ -25,6 +25,7 @@ Create the bucket and roles:
 
 ```
 # Use your account number below
+ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
 aws s3 mb s3://eksworkshop-${ACCOUNT_ID}-codepipeline-artifacts
 
 cd ~/environment


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Weave URLs were incorrect after it recently joined the CNCF.  Updated the URL, the Dockerfile location, and simplified getting the AWS account ID. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
