### PR TITLE
Helm: Add the Bitmani Repository > Missing repo update step

### DIFF
--- a/content/helm_root/helm_nginx/addbitnamirepo.md
+++ b/content/helm_root/helm_nginx/addbitnamirepo.md
@@ -14,6 +14,12 @@ To add the Bitnami Chart repo to our local list of searchable charts:
 helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
+Now that the repo is added, we need to update the Bitnami repo:
+
+```
+helm repo update bitnami
+```
+
 Once that completes, we can search all Bitnami Charts:
 
 ```


### PR DESCRIPTION
Adding the repo to Helm does not automatically update the repo content, which results in the next step returning no results. This PR corrects the omitted step.

*Issue #, if available:*

*Description of changes:*

Additional step added with commentary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
