### PR TITLE
removed notice warning

### DIFF
--- a/content/codepipeline/_index.md
+++ b/content/codepipeline/_index.md
@@ -7,12 +7,6 @@ draft: false
 
 # CI/CD with CodePipeline
 
-{{% notice warning %}}
-This chapter does not work in the AWS supplied event environments yet. If you are
-**at an AWS event**, please skip this chapter. If you are working in your own account,
-you should have no issues.
-{{% /notice %}}
-
 [Continuous integration](https://aws.amazon.com/devops/continuous-integration/) (CI) and [continuous delivery](https://aws.amazon.com/devops/continuous-delivery/) (CD)
 are essential for deft organizations. Teams are more productive when they can make discrete changes frequently, release those changes programmatically and deliver updates
 without disruption.


### PR DESCRIPTION
CodeBuild, CodeCommit, CodePipeline, CodeDeploy, and CodeStar are supported now by the tooling for AWS account provisioning for events. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
