### PR TITLE
update minor typo of kfctl version.

### DIFF
--- a/content/kubeflow/install.md
+++ b/content/kubeflow/install.md
@@ -22,7 +22,7 @@ Scaling the nodegroup will take 2 - 3 minutes.
 
 ### Install Kubeflow on Amazon EKS
 
-Download 0.7 RC6 release of `kfctl`. This binary will allow you to install Kubeflow on Amazon EKS:
+Download 0.7 release of `kfctl`. This binary will allow you to install Kubeflow on Amazon EKS:
 
 ```
 curl --silent --location "https://github.com/kubeflow/kubeflow/releases/download/v0.7.0/kfctl_v0.7.0_linux.tar.gz" | tar xz -C /tmp

--- a/content/x-ray/daemonset.files/xray-k8s-daemonset.yaml
+++ b/content/x-ray/daemonset.files/xray-k8s-daemonset.yaml
@@ -41,6 +41,9 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: xray-daemon
   template:
     metadata:
       labels:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed minor typo of kfctl version, it should be “0.7" rather than "0.7 RC6" at https://eksworkshop.com/kubeflow/install/ as per download URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
