### PR TITLE
Use -j to prevent jq from printing a newline

### DIFF
--- a/content/advanced/420_kubeflow/training.md
+++ b/content/advanced/420_kubeflow/training.md
@@ -46,8 +46,8 @@ aws iam create-access-key --user-name s3user > /tmp/create_output.json
 
 Next, record the new user's credentials into environment variables:
 ```
-export AWS_ACCESS_KEY_ID_VALUE=$(jq -r .AccessKey.AccessKeyId /tmp/create_output.json | base64)
-export AWS_SECRET_ACCESS_KEY_VALUE=$(jq -r .AccessKey.SecretAccessKey /tmp/create_output.json | base64)
+export AWS_ACCESS_KEY_ID_VALUE=$(jq -j .AccessKey.AccessKeyId /tmp/create_output.json | base64)
+export AWS_SECRET_ACCESS_KEY_VALUE=$(jq -j .AccessKey.SecretAccessKey /tmp/create_output.json | base64)
 ```
 
 Apply to EKS cluster:


### PR DESCRIPTION
*Issue #, if available:*
#542 

*Description of changes:*
Last PR changed `echo -n` to `jq -r` which is good and make setup easier but it brought a problem and results is inconsistent with `echo -n`, we change to `jq -j` to make sure it won't print a newline at the end of output, which will give exact same result as `echo -n`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

```
$ jq -j .AccessKey.AccessKeyId /tmp/create_output.json | base64
QUtJQVZDRFROSUxHQUdENklQUFo=

$ echo -n 'AKIAVCDTNILGAGD6IPPZ' | base64
QUtJQVZDRFROSUxHQUdENklQUFo=
```

