### PR TITLE
update kubectl version to 1.14.x

### DIFF
--- a/content/prerequisites/k8stools.md
+++ b/content/prerequisites/k8stools.md
@@ -15,8 +15,7 @@ for the download links.](https://docs.aws.amazon.com/eks/latest/userguide/gettin
 
 #### Install kubectl
 ```
-sudo curl --silent --location -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.7/bin/linux/amd64/kubectl
-
+sudo curl --silent --location -o /usr/local/bin/kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
 
 sudo chmod +x /usr/local/bin/kubectl
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated the downloading link for the Amazon EKS-vended kubectl binary.
-  Updated kubectl version to 1.14.x (eksctl creates EKS cluster 1.14.x

by default)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
