### PR TITLE
Fix to work on zsh

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/prerequisites.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/prerequisites.md
@@ -70,8 +70,8 @@ aws ec2 create-tags --resources $CGNAT_SNET3 --tags Key=kubernetes.io/role/elb,V
 ```
 As next step, we need to associate three new subnets into a route table. Again for simplicity, we chose to add new subnets to the Public route table that has connectivity to Internet Gateway
 ```
-SNET1=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=192.168.0.0/19 | jq -r .Subnets[].SubnetId)
-RTASSOC_ID=$(aws ec2 describe-route-tables --filters Name=association.subnet-id,Values=$SNET1 | jq -r .RouteTables[].RouteTableId)
+SNET1=$(aws ec2 describe-subnets --filters Name=cidr-block,Values=192.168.0.0/19 | jq -r '.Subnets[].SubnetId')
+RTASSOC_ID=$(aws ec2 describe-route-tables --filters Name=association.subnet-id,Values=$SNET1 | jq -r '.RouteTables[].RouteTableId')
 aws ec2 associate-route-table --route-table-id $RTASSOC_ID --subnet-id $CGNAT_SNET1
 aws ec2 associate-route-table --route-table-id $RTASSOC_ID --subnet-id $CGNAT_SNET2
 aws ec2 associate-route-table --route-table-id $RTASSOC_ID --subnet-id $CGNAT_SNET3


### PR DESCRIPTION
Tried it, and it didn't work on zsh without the quotes.

*Description of changes:*
* Just added `'` around the `jq` arguments, just like on line 17.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
