### PR TITLE
Use EKSCTL for Spot

### DIFF
--- a/content/beginner/150_spotworkers/cleanup.md
+++ b/content/beginner/150_spotworkers/cleanup.md
@@ -22,13 +22,13 @@ kubectl delete -f kubernetes/deployment.yaml
 Cleanup the Spot Handler Daemonset
 
 ```bash
-kubectl delete -f ~/environment/spot/spot-interrupt-handler-example.yml
+kubectl delete -k https://github.com/aws/aws-node-termination-handler/config/overlays/spot-node-selector?ref=master
 ```
 
-To clean up the worker created by this module, run the following commands:
-
-Remove the Worker nodes from EKS:
+To delete the label and the Node Group created  by this module, run the following commands
 
 ```bash
-aws cloudformation delete-stack --stack-name "eksworkshop-spot-workers"
+ kubectl label nodes --all lifecycle-
+
+eksctl delete nodegroup -f  ~/environment/eks-workshop-ng-spot.yaml --approve
 ```

--- a/content/beginner/150_spotworkers/deployhandler.md
+++ b/content/beginner/150_spotworkers/deployhandler.md
@@ -7,9 +7,10 @@ draft: false
 
 In this section, we will prepare our cluster to handle Spot interruptions.
 
-If the available On-Demand capacity of a particular instance type is depleted, the Spot Instance is sent an interruption notice two minutes ahead to gracefully wrap up things. We will deploy a pod on each spot instance to detect and redeploy applications elsewhere in the cluster
+If the available On-Demand capacity of a particular instance type is depleted, the Spot Instance is sent an interruption notice two minutes ahead to gracefully wrap up things. We will deploy a pod on each spot instance to detect and redeploy applications elsewhere in the cluster.
 
-The first thing that we need to do is deploy the Spot Interrupt Handler on each Spot Instance. This will monitor the EC2 metadata service on the instance for a interruption notice.
+The first thing that we need to do is deploy the [AWS Node Termination Handler](https://github.com/aws/aws-node-termination-handler) on each Spot Instance. This will monitor the EC2 metadata service on the instance for an interruption notice.
+The termination handler consists of a `ServiceAccount`, `ClusterRole`, `ClusterRoleBinding`, and a `DaemonSet`.
 
 The workflow can be summarized as:
 
@@ -19,45 +20,14 @@ The workflow can be summarized as:
 * [**Drain**](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/) connections on the running pods.
 * Replace the pods on remaining nodes to maintain the desired capacity.
 
-We have provided an example K8s DaemonSet manifest. A DaemonSet runs one pod per node.
+By default, the **aws-node-termination-handler** will run on all of your nodes (on-demand and spot). If your spot instances are labeled, you can configure `aws-node-termination-handler` to only run on your labeled spot nodes. If you're using the tag `lifecycle=Ec2Spot`, you can run the following to apply our spot-node-selector overlay.
 
 ```bash
-mkdir ~/environment/spot
-cd ~/environment/spot
-wget https://eksworkshop.com/spot/managespot/deployhandler.files/spot-interrupt-handler-example.yml
+kubectl apply -k https://github.com/aws/aws-node-termination-handler/config/overlays/spot-node-selector?ref=master
 ```
-
-As written, the manifest will deploy pods to all nodes including On-Demand, which is a waste of resources. We want to edit our DaemonSet to only be deployed on Spot Instances. Let's use the labels to identify the right nodes.
-
-Use a `nodeSelector` to constrain our deployment to spot instances. View this [**link**](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for more details.
-
-#### Challenge
-
-**Configure our Spot Handler to use nodeSelector**
-{{% expand "Expand here to see the solution"%}}
-Place this at the end of the DaemonSet manifest under Spec.Template.Spec.nodeSelector
-
-```bash
-      nodeSelector:
-        lifecycle: Ec2Spot
-```
-
-{{% /expand %}}
-
-Deploy the DaemonSet
-
-```bash
-kubectl apply -f ~/environment/spot/spot-interrupt-handler-example.yml
-```
-
-{{% notice tip %}}
-If you receive an error deploying the DaemonSet, there is likely a small error in the YAML file. We have provided a solution file at the bottom of this page that you can use to compare.
-{{% /notice %}}
 
 View the pods. There should be one for each spot node.
 
 ```bash
-kubectl get daemonsets
+kubectl --namespace=kube-system get daemonsets 
 ```
-
-{{%attachments title="Related files" pattern=".yml"/%}}

--- a/content/beginner/150_spotworkers/preferspot.md
+++ b/content/beginner/150_spotworkers/preferspot.md
@@ -57,7 +57,7 @@ Add this to your deployment file under spec.template.spec
 First let's take a look at all pods deployed on Spot instances
 
 ```bash
- for n in $(kubectl get nodes -l lifecycle=Ec2Spot --no-headers | cut -d " " -f1); do kubectl get pods --all-namespaces  --no-headers --field-selector spec.nodeName=${n} ; done
+ for n in $(kubectl get nodes -l lifecycle=Ec2Spot --no-headers | cut -d " " -f1); do echo "Pods on instance ${n}:";kubectl get pods --all-namespaces  --no-headers --field-selector spec.nodeName=${n} ; echo ; done
 ```
 
 Now we will redeploy  our microservices with our edited Frontend Manifest
@@ -79,5 +79,5 @@ kubectl apply -f kubernetes/deployment.yaml
 We can again check all pods deployed on Spot Instances and should now see the frontend pods running on Spot instances
 
 ```bash
- for n in $(kubectl get nodes -l lifecycle=Ec2Spot --no-headers | cut -d " " -f1); do kubectl get pods --all-namespaces  --no-headers --field-selector spec.nodeName=${n} ; done
+ for n in $(kubectl get nodes -l lifecycle=Ec2Spot --no-headers | cut -d " " -f1); do echo "Pods on instance ${n}:";kubectl get pods --all-namespaces  --no-headers --field-selector spec.nodeName=${n} ; echo ; done
 ```

--- a/content/beginner/150_spotworkers/workers.md
+++ b/content/beginner/150_spotworkers/workers.md
@@ -4,81 +4,47 @@ date: 2018-08-07T11:05:19-07:00
 weight: 10
 draft: false
 ---
+We have our EKS Cluster and worker nodes already, but we need some Spot Instances configured as workers. We also need a Node Labeling strategy to identify which instances are Spot and which are on-demand so that we can make more intelligent scheduling decisions. We will use `eksctl` to launch new worker nodes that will connect to the EKS cluster.
 
-We have our EKS Cluster and worker nodes already, but we need some Spot Instances configured as workers. We also need a Node Labeling strategy to identify which instances are Spot and which are on-demand so that we can make more intelligent scheduling decisions. We will use [AWS CloudFormation](https://aws.amazon.com/cloudformation/) to launch new worker
-nodes that will connect to the EKS cluster.
-
-This template will create a single ASG that leverages the latest feature to mix multiple instance types and purchase as a single K8s nodegroup. Check out this blog: [New – EC2 Auto Scaling Groups With Multiple Instance Types & Purchase Options](https://aws.amazon.com/tw/blogs/aws/new-ec2-auto-scaling-groups-with-multiple-instance-types-purchase-options/) for details.
-
-#### Retrieve the Worker Node Instance Profile ARN
-
-First, we will need to ensure the ARN Name our workers use is set in our environment:
+But first, we will add a new label to the OnDemand worker nodes
 
 ```bash
-test -n "$INSTANCE_PROFILE_ARN" && echo INSTANCE_PROFILE_ARN is "$INSTANCE_PROFILE_ARN" || echo INSTANCE_PROFILE_ARN is not set
+kubectl label nodes --all 'lifecycle=OnDemand'
 ```
 
-Copy the Profile ARN for use as a Parameter in the next step. If you receive an error or empty response, expand the steps below to export.
+#### Create Spot worker nodes
 
-{{%expand "Expand here if you need to export the Instance Profile ARN" %}}
-If `INSTANCE_PROFILE_ARN` is not set, please review: [/030_eksctl/test/](/030_eksctl/test/)
-{{% /expand %}}
-
-```text
-# Example Output
-INSTANCE_PROFILE_ARN is arn:aws:iam::123456789101:instance-profile/eksctl-eksworkshop-eksctl-nodegroup-ng-abcd1234-NodeInstanceProfile-ABCDEF1234
-```
-
-#### Retrieve the Security Group Name
-We also need to collect the ID of the security group used with the existing worker nodes.
+We are now ready to create new worker nodes.
 
 ```bash
-STACK_NAME=$(aws cloudformation describe-stacks | jq -r '.Stacks[].StackName' | grep eksctl-eksworkshop-eksctl-nodegroup)
-SG_ID=$(aws cloudformation describe-stack-resources --stack-name $STACK_NAME --logical-resource-id SG | jq -r '.StackResources[].PhysicalResourceId')
-echo $SG_ID
+cat << EoF > ~/environment/eks-workshop-ng-spot.yaml
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: eksworkshop-eksctl 
+  region: ${AWS_REGION}
+nodeGroups:
+  - name: ng-spot
+    labels:
+      lifecycle: Ec2Spot
+    taints:
+      spotInstance: true:PreferNoSchedule
+    minSize: 2
+    maxSize: 5
+    instancesDistribution: # At least two instance types should be specified
+      instanceTypes:
+        - m4.large
+        - c4.large
+        - c5.large
+      onDemandBaseCapacity: 0
+      onDemandPercentageAboveBaseCapacity: 0 # all the instances will be spot instances
+      spotInstancePools: 2
+EoF
+
+eksctl create nodegroup -f ~/environment/eks-workshop-ng-spot.yaml
 ```
 
-```text
-# Example Output
-sg-0d9fb7e709dff5675
-```
-
-#### Launch the CloudFormation Stack
-
-We will launch the CloudFormation template as a new set of worker nodes, but it's also possible to update the nodegroup CloudFormation stack created by the *eksctl* tool.
-
-Click the **Launch** button to create the CloudFormation stack in the AWS Management Console.
-
-| Launch template |  |  |
-| ------ |:------:|:--------:|
-| EKS Workers - Spot and On Demand |  {{< cf-launch "amazon-eks-nodegroup-with-mixed-instances.yml?stackName=eksworkshop-nodegroup-0" >}} | {{< cf-download "amazon-eks-nodegroup-with-mixed-instances.yml" >}}  |
-
-{{% notice tip %}}
-Confirm the region is correct based on where you've deployed your cluster.
-{{% /notice %}}
-Once the console is open you will need to configure the missing parameters. Use the table below for guidance.
-
-| Parameter | Value |
-|-----------|-------|
-|Stack Name: | eksworkshop-spot-workers |
-|Cluster Name: | eksworkshop-eksctl (or whatever you named your cluster) |
-|ClusterControlPlaneSecurityGroup: | Select from the dropdown. It will contain your cluster name and the words **'ControlPlaneSecurityGroup'** |
-|NodeInstanceProfile: | Use the Instance Profile ARN that copied in the step above. (e.g.eks-workshop-nodegroup)
-|UseExistingNodeSecurityGroups: | Leave as **'Yes'** |
-|ExistingNodeSecurityGroups: | Use the SG name that copied in the step above. (e.g. sg-0123456789abcdef)
-|NodeImageId: | Visit this [**link**](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html) and select the non-GPU image for your region - **Check for empty spaces in copy/paste**|
-|KeyName: | SSH Key Pair created earlier or any valid key will work |
-|NodeGroupName: | Leave as **spotworkers** |
-|VpcId: | Select your workshop VPC from the dropdown |
-|Subnets: | Select the 3 **private** subnets for your workshop VPC from the dropdown |
-|BootstrapArgumentsForOnDemand: | `--kubelet-extra-args --node-labels=lifecycle=OnDemand` |
-|BootstrapArgumentsForSpotFleet: | `--kubelet-extra-args '--node-labels=lifecycle=Ec2Spot --register-with-taints=spotInstance=true:PreferNoSchedule'` |
-
-#### What's going on with Bootstrap Arguments?
-
-The EKS Bootstrap.sh script is packaged into the EKS Optimized AMI that we are using, and only requires a single input, the **EKS Cluster name**. The bootstrap script supports setting any `kubelet-extra-args` at runtime. We have configured **node-labels** so that kubernetes knows what type of nodes we have provisioned. We set the **lifecycle** for the nodes as **OnDemand** or **Ec2Spot**. We are also [tainting](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) with **PreferNoSchedule** to prefer pods not be scheduled on Spot Instances. This is a “preference” or “soft” version of **NoSchedule** – the system will try to avoid placing a pod that does not tolerate the taint on the node, but it is not required.
-
-You can leave the rest of the default parameters as is and continue through the remaining CloudFormation screens. Check the box next to **I acknowledge that AWS CloudFormation might create IAM resources** and click **Create**
+During the creation of the Node Group, we have configured a **node-label** so that kubernetes knows what type of nodes we have provisioned. We set the **lifecycle** for the nodes as **Ec2Spot**. We are also [tainting](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) with **PreferNoSchedule** to prefer pods not be scheduled on Spot Instances. This is a “preference” or “soft” version of **NoSchedule** – the system will try to avoid placing a pod that does not tolerate the taint on the node, but it is not required.
 
 {{% notice info %}}
 The creation of the workers will take about 3 minutes.
@@ -86,24 +52,24 @@ The creation of the workers will take about 3 minutes.
 
 #### Confirm the Nodes
 
-Confirm that the new nodes joined the cluster correctly. You should see 2-3 more nodes added to the cluster.
+Confirm that the new nodes joined the cluster correctly. You should see 2 more nodes added to the cluster.
 
 ```bash
 kubectl get nodes
 ```
 
 ![All Nodes](/images/spotworkers/spot_get_nodes.png)
-You can use the node-labels to identify the lifecycle of the nodes
+You can use the node-labels to identify the lifecycle of the nodes.
 
 ```bash
 kubectl get nodes --show-labels --selector=lifecycle=Ec2Spot
 ```
 
-The output of this command should return 2 nodes. At the end of the node output, you should see the node label **lifecycle=Ec2Spot**
+The output of this command should return 2 nodes. At the end of the node output, you should see the node label **lifecycle=Ec2Spot**.
 
 ![Spot Output](/images/spotworkers/spot_get_spot.png)
 
-Now we will show all nodes with the **lifecycle=OnDemand**. The output of this command should return 1 node as configured in our CloudFormation template.
+Now we will show all nodes with the **lifecycle=OnDemand**. The output of this command should return multiple nodes as configured in `eksctl` YAMl template.
 
 ```bash
 kubectl get nodes --show-labels --selector=lifecycle=OnDemand


### PR DESCRIPTION
*Issue #, if available:*
Could be a long term fix for: https://github.com/aws-samples/eks-workshop/issues/587
*Description of changes:*
**Why**
- It is easier to create and manipulate spot instance using `eksctl`  (compared to CloudFormation)

**How**

-  I updated all the pages to use `eksctl` instead of cloudformation
-  I replaced the spot interrupt handler by `aws-node-termination-handler`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
