### PR TITLE
remove a wait flag from a command that doesn't need it (minor fix)

### DIFF
--- a/content/beginner/170_statefulset/testfailure.md
+++ b/content/beginner/170_statefulset/testfailure.md
@@ -51,7 +51,7 @@ kubectl exec mysql-2 -c mysql -- mv /usr/bin/mysql.off /usr/bin/mysql
 ```
 Check the status again to see that both containers are running and healthy
 ```
-$ kubectl get pod -w mysql-2
+$ kubectl get pod mysql-2
 ```
 ```
 NAME      READY     STATUS    RESTARTS   AGE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- remove a wait flag from a `kubectl` command that doesn't need it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
