### PR TITLE
Update installnginx.md

### DIFF
--- a/content/beginner/060_helm/helm_nginx/installnginx.md
+++ b/content/beginner/060_helm/helm_nginx/installnginx.md
@@ -52,7 +52,7 @@ The first object shown in this output is a [Deployment](https://kubernetes.io/do
 You can inspect this Deployment object in more detail by running the following command:
 
 ```
-kubectl describe deployment mywebserver-nginx
+kubectl describe deployment mywebserver
 ```
 
 The next object shown created by the Chart is a [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod/).  A Pod is a group of one or more containers.


### PR DESCRIPTION
*Issue #, if available:*

If deployment in workshop  scenario was spelcified as:
`helm install --name mywebserver bitnami/nginx`

then kubectl needs to follow same naming convention:
`kubectl describe deployment mywebserver`

rather than:
`kubectl describe deployment mywebserver-nginx`

as otherwise, below error gets thrown at uer following lab:
`Error from server (NotFound): deployments.extensions "mywebserver-nginx" not found`

*Description of changes:*
Correct deployment name has been suggested


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
