### PR TITLE
updated Cluster Autoscaler (CA) documentation

### DIFF
--- a/content/beginner/080_scaling/_index.md
+++ b/content/beginner/080_scaling/_index.md
@@ -13,4 +13,4 @@ In this Chapter, we will show patterns for scaling your worker nodes and applica
 
 * **Horizontal Pod Autoscaler (HPA)** scales the pods in a deployment or replica set. It is implemented as a K8s API resource and a controller. The controller manager queries the resource utilization against the metrics specified in each HorizontalPodAutoscaler definition. It obtains the metrics from either the resource metrics API (for per-pod resource metrics), or the custom metrics API (for all other metrics).
 
-* **Cluster Autoscaler (CA)** is the default K8s component that can be used to perform pod scaling as well as scaling nodes in a cluster. It automatically increases the size of an Auto Scaling group so that pods have a place to run. And it attempts to remove idle nodes, that is, nodes with no running pods.
+* **Cluster Autoscaler (CA)** a component that automatically adjusts the size of a Kubernetes Cluster so that all pods have a place to run and there are no unneeded nodes.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/eks-workshop/issues/621

*Description of changes:*
CA cant be used for pod scaling. Updated intro from CA github page @: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-is-cluster-autoscaler

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
