### PR TITLE
Fixing typo in security group name for Tigera section.

### DIFF
--- a/content/beginner/120_network-policies/tigera/environment.md
+++ b/content/beginner/120_network-policies/tigera/environment.md
@@ -36,7 +36,7 @@ The following commands will set the remainder of the environment variables.
 
 ```
 VPC_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query 'cluster.resourcesVpcConfig.vpcId' --output text)
-K8S_NODE_SGS=$(aws ec2 describe-security-groups --filters Name=tag:aws:cloudformation:logical-id,Values=SG Name=vpc-id,Values=${VPC_ID} --query "SecurityGroups[0].GroupId" --output text)
+K8S_NODE_SGS=$(aws ec2 describe-security-groups --filters Name=tag:aws:cloudformation:logical-id,Values=ClusterSharedNodeSecurityGroup Name=vpc-id,Values=${VPC_ID} --query "SecurityGroups[0].GroupId" --output text)
 CONTROL_PLANE_SG=$(aws ec2 describe-security-groups --filters Name=tag:aws:cloudformation:logical-id,Values=ControlPlaneSecurityGroup Name=vpc-id,Values=${VPC_ID} --query "SecurityGroups[0].GroupId" --output text)
 ```
 


### PR DESCRIPTION
Issue https://github.com/aws-samples/eks-workshop/issues/625

*Description of changes:*
Fixing a possible typo in a security group value

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
