### PR TITLE
training.md: Remove invalid bucket name possibility

### DIFF
--- a/content/advanced/420_kubeflow/training.md
+++ b/content/advanced/420_kubeflow/training.md
@@ -24,7 +24,7 @@ Alternatively, you can use [Dockerfile](/advanced/420_kubeflow/kubeflow.files/Do
 Create an S3 bucket where training model will be saved:
 
 ```
-export HASH=$(< /dev/urandom tr -dc a-z-0-9 | head -c6)
+export HASH=$(< /dev/urandom tr -dc a-z0-9 | head -c6)
 export S3_BUCKET=$HASH-eks-ml-data
 aws s3 mb s3://$S3_BUCKET --region $AWS_REGION
 ```


### PR DESCRIPTION
*Description of changes:*
Previous HASH could be generated with a dash at the beginning which results in an invalid bucket name (or a hash at the end which looks odd). This reduces it to just alphanumeric.

Example of previous usage which results in invalid bucket name:
```
$ export HASH=$(< /dev/urandom tr -dc a-z-0-9 | head -c6)
$ export S3_BUCKET=$HASH-eks-ml-data
$ aws s3 mb s3://$S3_BUCKET --region $AWS_REGIONmake_bucket failed: s3://-z1d0e-eks-ml-data An error occurred (InvalidBucketName) when calling the CreateBucket operation: The specified bucket is not valid.
$ echo $HASH
-z1d0e
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
