### PR TITLE
Helm 3 changes

### DIFF
--- a/content/beginner/060_helm/helm_nginx/cleaningup.md
+++ b/content/beginner/060_helm/helm_nginx/cleaningup.md
@@ -22,7 +22,7 @@ mywebserver     1               Tue Nov 13 19:55:25 2018        DEPLOYED        
 It was a lot of fun; we had some great times sending HTTP back and forth, but now its time to delete this deployment.  To delete:
 
 ```
-helm delete --purge mywebserver
+helm delete mywebserver
 ```
 
 And you should be met with the output:


### PR DESCRIPTION
helm delete --purge is now default behavior of helm delete in helm 3.  Specifying --purge gives an error, as the flag no longer exists. https://helm.sh/docs/topics/v2_v3_migration/#overview-of-helm-3-changes

_Commands removed/replaced/added:
delete –> uninstall : removes all release history by default (previously needed --purge)_

I suggest this change because the eksworkshop if run today from scratch is using helm 3, based on my brew install of helm that I did today.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
