### PR TITLE
Update connect.md

### DIFF
--- a/content/beginner/040_dashboard/connect.md
+++ b/content/beginner/040_dashboard/connect.md
@@ -15,7 +15,7 @@ Now we can access the Kubernetes Dashboard
 
 Open a New Terminal Tab  and enter
 ```
-aws eks get-token --cluster-name eksworkshop-eksctl | jq -r '.status.token'
+kubectl -n kube-system describe secret $(kubectl -n kube-system get secret | grep eks-admin | awk '{print $1}')
 ```
 
 Copy the output of this command and then click the radio button next to


### PR DESCRIPTION

*Issue #, if available:*

There is no `aws eks get-token` command

```sh
aws eks help

### output
...
AVAILABLE COMMANDS
       o create-cluster

       o delete-cluster

       o describe-cluster

       o help

       o list-clusters

       o update-kubeconfig
```


*Description of changes:*

Following the [EKS docs](https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html)

replaced former command to get token with what is in the documentation. 

`kubectl -n kube-system describe secret $(kubectl -n kube-system get secret | grep eks-admin | awk '{print $1}')`

It may be helpful to point out that the service account *eks-admin* needs to be made.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
