### PR TITLE
Reorder Helm installation steps

### DIFF
--- a/content/beginner/060_helm/helm_intro/install.md
+++ b/content/beginner/060_helm/helm_intro/install.md
@@ -4,10 +4,9 @@ date: 2018-08-07T08:30:11-07:00
 weight: 5
 ---
 
-Before we can get started configuring `helm` we'll need to:
+Before we can deploy [charts](https://helm.sh/docs/topics/charts/) with `Helm` we'll need to:
   * Configure Helm access with RBAC
-  * install the command line tools that you will interact with.
-
+  * Install the command line tools that you will interact with.
 
 ## Configure Helm access with RBAC
 
@@ -43,6 +42,7 @@ kubectl apply -f ~/environment/helm-rbac.yaml
 
 
 ## Install the Helm client
+
 {{% notice warning %}}
 Once you install helm, the command will prompt you to run `helm init`. **Do not run this command**.
 If you accidentally run 'helm init', you can safely uninstall tiller by running `helm reset --force`

--- a/content/beginner/060_helm/helm_intro/install.md
+++ b/content/beginner/060_helm/helm_intro/install.md
@@ -14,7 +14,7 @@ Before we can deploy [charts](https://helm.sh/docs/topics/charts/) with `Helm` w
 
 To create a new service account manifest:
 ```bash
-cat <<EoF > ~/environment/heml-rbac.yaml
+cat <<EoF > ~/environment/helm-rbac.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/content/beginner/060_helm/helm_intro/install.md
+++ b/content/beginner/060_helm/helm_intro/install.md
@@ -4,32 +4,18 @@ date: 2018-08-07T08:30:11-07:00
 weight: 5
 ---
 
-Before we can get started configuring `helm` we'll need to first install the command line tools that you will interact with. To do this run the following.
+Before we can get started configuring `helm` we'll need to:
+  * Configure Helm access with RBAC
+  * install the command line tools that you will interact with.
 
-{{% notice info %}}
-Once you install helm, the command will prompt you to run 'helm init'. **Do not run 'helm init'.** Follow the instructions to configure helm using **Kubernetes RBAC** and then install tiller as specified below
-If you accidentally run 'helm init', you can safely uninstall tiller by running `helm reset --force`
-{{% /notice %}}
 
-```
-cd ~/environment
+## Configure Helm access with RBAC
 
-curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
-
-chmod +x get_helm.sh
-
-./get_helm.sh
-```
-
-### Configure Helm access with RBAC
-
-Helm relies on a service called **tiller** that requires special permission on the
-kubernetes cluster, so we need to build a _**Service Account**_ for **tiller**
-to use. We'll then apply this to the cluster.
+`Helm` relies on a service called **tiller** that requires special permission on the kubernetes cluster, so we need to create a _**Service Account**_ for **tiller**.
 
 To create a new service account manifest:
-```
-cat <<EoF > ~/environment/rbac.yaml
+```bash
+cat <<EoF > ~/environment/heml-rbac.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -50,21 +36,36 @@ subjects:
     name: tiller
     namespace: kube-system
 EoF
+
+# we can now apply the rbac config for helm
+kubectl apply -f ~/environment/helm-rbac.yaml
 ```
 
-Next apply the config:
-```
-kubectl apply -f ~/environment/rbac.yaml
+
+## Install the Helm client
+{{% notice warning %}}
+Once you install helm, the command will prompt you to run `helm init`. **Do not run this command**.
+If you accidentally run 'helm init', you can safely uninstall tiller by running `helm reset --force`
+{{% /notice %}}
+
+```bash
+cd ~/environment
+
+curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+
+chmod +x get_helm.sh
+
+./get_helm.sh
 ```
 
-Then we can install **tiller** using the **helm** tooling
 
-```
+## Install **tiller** using the **helm** tooling
+
+```bash
 helm init --service-account tiller
 ```
 
-This will install **tiller** into the cluster which gives it access to manage
-resources in your cluster.
+This will install **tiller** into the cluster which gives it access to manage resources in your cluster.
 
 Activate helm bash-completion
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To avoid receiving helm installation issues like `running helm init before configuring RBAC` like PR #658 


I reorder the steps to install helm client:

- RBAC configs instructions are now **before** the client installation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
