### PR TITLE
RBAC: Add raw flag to JQ command

### DIFF
--- a/content/beginner/090_rbac/create_iam_user.md
+++ b/content/beginner/090_rbac/create_iam_user.md
@@ -34,7 +34,7 @@ To make it easy to switch back and forth between the admin user you created the 
 
 ```
 cat << EoF > rbacuser_creds.sh
-export AWS_SECRET_ACCESS_KEY=$(jq .AccessKey.SecretAccessKey /tmp/create_output.json)
-export AWS_ACCESS_KEY_ID=$(jq .AccessKey.AccessKeyId /tmp/create_output.json)
+export AWS_SECRET_ACCESS_KEY=$(jq -r .AccessKey.SecretAccessKey /tmp/create_output.json)
+export AWS_ACCESS_KEY_ID=$(jq -r .AccessKey.AccessKeyId /tmp/create_output.json)
 EoF
 ```


### PR DESCRIPTION
Issue #, if available:
Under RBAC, Create User step has a bug that will cause the Test user step to fail.

Description of changes: when setting the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID using JQ command, without specifying the -r flag, values will have enclosing double quotes which will fail the subsequent steps in this lesson.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
