### PR TITLE
Fix autoscaler logic to deploy dynamically an up-to-date version matc…

### DIFF
--- a/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
+++ b/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
@@ -120,7 +120,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.2.2
+        - image: k8s.gcr.io/cluster-autoscaler:v${AUTOSCALER_VERSION}
           name: cluster-autoscaler
           resources:
             limits:
@@ -138,7 +138,7 @@ spec:
             - --nodes=2:8:<AUTOSCALING GROUP NAME>
           env:
             - name: AWS_REGION
-              value: us-west-2
+              value: <AWS_REGION_NAME>
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs/ca-certificates.crt

--- a/content/beginner/080_scaling/deploy_ca.md
+++ b/content/beginner/080_scaling/deploy_ca.md
@@ -19,6 +19,14 @@ cd ~/environment/cluster-autoscaler
 wget https://eksworkshop.com/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
 ```
 
+Populate the manifest file with the most-up-to-date Cluster Autoscaler image version for the actual Kubernetes version in EKS.
+
+```
+export K8S_VERSION=$(kubectl version --short | grep 'Server Version:' | sed 's/[^0-9.]*\([0-9.]*\).*/\1/' | cut -d. -f1,2)
+export AUTOSCALER_VERSION=$(curl -s "https://api.github.com/repos/kubernetes/autoscaler/releases" | grep '"tag_name":' | sed -s 's/.*-\([0-9][0-9\.]*\).*/\1/' | grep -m1 ${K8S_VERSION})
+envsubst < cluster_autoscaler.yml | kubectl create -f -
+```
+
 ### Configure the ASG
 We will need to provide the name of the Autoscaling Group that we want CA to manipulate. Collect the name of the Auto Scaling Group (ASG) containing your worker nodes. Record the name somewhere. We will use this later in the manifest file.
 
@@ -41,7 +49,7 @@ Click `Save`
 
 Using the file browser on the left, open cluster_autoscaler.yml
 
-Search for `command:` and within this block, replace the placeholder text `<AUTOSCALING GROUP NAME>` with the ASG name that you copied in the previous step. Also, update **AWS_REGION** value to reflect the region you are using and **Save** the file.
+Search for `command:` and within this block, replace the placeholder text `<AUTOSCALING GROUP NAME>` with the ASG name that you copied in the previous step. Also, insert the **AWS_REGION** value by replacing the `<AWS_REGION_NAME>` placeholder to reflect the region you are using and **Save** the file.
 
 {{< output >}}
 command:


### PR DESCRIPTION
- Fix autoscaler logic to deploy dynamically an up-to-date version matching the running k8s version. - Remove hardcoded region name in cluster_autoscaler.yml by replacing it with a placeholder.

*Issue #, if available:*
Issue #180 
Issue #294 

*Description of changes:*
Cluster Autoscaler version used in the workshop is outdated. Actual used version (1.2.2) is almost 2 years old. In the meanwhile a lot of fixes and upgrades have been released, which have improved CA performance, stability and SDK compatibility for EKS.

It is recommended to use the Cluster Autoscaler version with the Kubernetes version for which it was meant. Although it is claimed that since version Kubernetes version 1.12 CA release versions should match each-other exactly (https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases), this is not always the case.

Because of this reason, this fix will dynamically search and apply the most recent CA available release which corresponds to the major Kubernetes release being used.

In addition, one occurrance of hardcoded region value has been replaced by a placeholder.

Please close the related isssues.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
