### PR TITLE
Correct command to upgrade / install the handler

### DIFF
--- a/content/beginner/150_spotworkers/deployhandler.md
+++ b/content/beginner/150_spotworkers/deployhandler.md
@@ -30,9 +30,10 @@ By default, the **aws-node-termination-handler** will run on all of your nodes (
 ```bash
 helm repo add eks https://aws.github.io/eks-charts
 
-helm install aws-node-termination-handler eks/aws-node-termination-handler \
+helm upgrade --install aws-node-termination-handler \
              --namespace kube-system \
-             --set nodeSelector.lifecycle=Ec2Spot
+             --set nodeSelector.lifecycle=Ec2Spot \
+              eks/aws-node-termination-handler
 ```
 
 Verify that the pods are only running on node with label `lifecycle=Ec2Spot`


### PR DESCRIPTION
Original command fails: 

````
helm install aws-node-termination-handler eks/aws-node-termination-handler \
>              --namespace kube-system \
>              --set nodeSelector.lifecycle=Ec2Spot
Error: This command needs 1 argument: chart name

````
Updated to "upgrade --install" -- as per  https://github.com/aws/aws-node-termination-handler -- and correct command format

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
