### PR TITLE
Fix eksctl download link: was downloading 0.13 instead of latest

### DIFF
--- a/content/030_eksctl/_index.md
+++ b/content/030_eksctl/_index.md
@@ -14,9 +14,8 @@ tags:
 
 # Launch using [eksctl](https://eksctl.io/)
 
-[eksctl](https://eksctl.io) is a tool jointly developed by AWS and [Weaveworks](https://weave.works) that automates much of
-the experience of creating EKS clusters.
+[eksctl](https://eksctl.io) is a tool jointly developed by AWS and [Weaveworks](https://weave.works) that automates much of the experience of creating EKS clusters.
 
-In this module, we will use eksctl to launch and configure our EKS cluster and nodes.
+In this module, we will use `eksctl` to launch and configure our EKS cluster and nodes.
 
 {{< youtube 3-OZqA5p1HA >}}

--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -9,13 +9,18 @@ weight: 20
 **DO NOT PROCEED** with this step unless you have [validated the IAM role](/020_prerequisites/workspaceiam/#validate-the-iam-role) in use by the Cloud9 IDE. You will not be able to run the necessary kubectl commands in the later modules unless the EKS cluster is built using the IAM role.
 {{% /notice %}}
 
-#### Challenge:
+#### Challenge
+
 **How do I check the IAM role on the workspace?**
 
 {{%expand "Expand here to see the solution" %}}
-Run `aws sts get-caller-identity` and validate that your _Arn_ contains `eksworkshop-admin`and an Instance Id.
+Run the command below and validate that your _Arn_ contains `eksworkshop-admin`and an Instance Id.
 
-```output
+```bash
+aws sts get-caller-identity
+```
+
+```json
 {
     "Account": "123456789012",
     "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef",
@@ -29,8 +34,14 @@ If you do see the correct role, proceed to next step to create an EKS cluster.
 {{% /expand %}}
 
 ### Create an EKS cluster
-```
-eksctl create cluster --name=eksworkshop-eksctl --nodes=3 --managed --alb-ingress-access --region=${AWS_REGION}
+
+```bash
+eksctl create cluster \
+    --name=eksworkshop-eksctl \
+    --nodes=3 \
+    --managed \
+    --alb-ingress-access \
+    --region=${AWS_REGION}
 ```
 
 {{% notice info %}}

--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -20,7 +20,7 @@ Run the command below and validate that your _Arn_ contains `eksworkshop-admin`a
 aws sts get-caller-identity
 ```
 
-```json
+```output
 {
     "Account": "123456789012",
     "UserId": "AROA1SAMPLEAWSIAMROLE:i-01234567890abcdef",

--- a/content/030_eksctl/prerequisites.md
+++ b/content/030_eksctl/prerequisites.md
@@ -5,20 +5,22 @@ weight: 10
 ---
 
 For this module, we need to download the [eksctl](https://eksctl.io/) binary:
-```
-curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 
+```bash
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 
-sudo mv -v /tmp/eksctl /usr/local/bin
+sudo mv /tmp/eksctl /usr/local/bin
 ```
 
-Confirm the eksctl command works:
-```
+Confirm the `eksctl` command works:
+
+```bash
 eksctl version
 ```
 
-Enable eksctl bash-completion
-```
+Enable `eksctl` bash-completion
+
+```bash
 eksctl completion bash >> ~/.bash_completion
 . /etc/profile.d/bash_completion.sh
 . ~/.bash_completion

--- a/content/030_eksctl/test.md
+++ b/content/030_eksctl/test.md
@@ -3,14 +3,15 @@ title: "Test the Cluster"
 date: 2018-08-07T13:36:57-07:00
 weight: 30
 ---
-#### Test the cluster:
+#### Test the cluster
+
 Confirm your nodes:
 
 ```bash
 kubectl get nodes # if we see our 3 nodes, we know we have authenticated correctly
 ```
 
-#### Export the Worker Role Name for use throughout the workshop:
+#### Export the Worker Role Name for use throughout the workshop
 
 ```bash
 STACK_NAME=$(eksctl get nodegroup --cluster eksworkshop-eksctl -o json | jq -r '.[].StackName')
@@ -18,6 +19,6 @@ ROLE_NAME=$(aws cloudformation describe-stack-resources --stack-name $STACK_NAME
 echo "export ROLE_NAME=${ROLE_NAME}" | tee -a ~/.bash_profile
 ```
 
-#### Congratulations!
+#### Congratulations
 
 You now have a fully working Amazon EKS Cluster that is ready to use!


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updated `eksctl` url based on the latest instruction from [weaveworks](https://github.com/weaveworks/eksctl/commit/49ce9b7bf7b684ffb7f19512bf6f718ad40323ef#diff-04c6e90faac2675aa89e2176d2eec7d8)
* Minor updates and fixes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
