### PR TITLE
Fix regression in CSI driver installation

### DIFF
--- a/content/beginner/170_statefulset/ebs_csi_driver.files/attacher-binding.yml
+++ b/content/beginner/170_statefulset/ebs_csi_driver.files/attacher-binding.yml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /subjects/0/name
+  value: ebs-csi-controller-irsa

--- a/content/beginner/170_statefulset/ebs_csi_driver.files/deployment.yml
+++ b/content/beginner/170_statefulset/ebs_csi_driver.files/deployment.yml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/spec/serviceAccount
+  value: ebs-csi-controller-irsa

--- a/content/beginner/170_statefulset/ebs_csi_driver.files/kustomization.yml
+++ b/content/beginner/170_statefulset/ebs_csi_driver.files/kustomization.yml
@@ -2,5 +2,27 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable?ref=master
-patchesStrategicMerge:
-- serviceaccount.yaml
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: ebs-csi-controller
+    namespace: kube-system
+  path: deployment.yml
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: ebs-csi-attacher-binding
+  path: attacher-binding.yml
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRoleBinding
+    name: ebs-csi-provisioner-binding
+  path: provisioner-binding.yml
+images:
+- name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
+  newName: amazon/aws-ebs-csi-driver
+  newTag: v0.5.0

--- a/content/beginner/170_statefulset/ebs_csi_driver.files/provisioner-binding.yml
+++ b/content/beginner/170_statefulset/ebs_csi_driver.files/provisioner-binding.yml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /subjects/0/name
+  value: ebs-csi-controller-irsa

--- a/content/beginner/170_statefulset/ebs_csi_driver.files/serviceaccount.yaml.tmpl
+++ b/content/beginner/170_statefulset/ebs_csi_driver.files/serviceaccount.yaml.tmpl
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ebs-csi-controller-sa
-  namespace: kube-system
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::${ACCOUNT_ID}:role/ebs-csi-driver


### PR DESCRIPTION
The recent update to use IRSA for the EBS CSI driver did not work
correctly.  Updated and retested on a fresh cluster to ensure it
works properly this time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
