### PR TITLE
Fix wording on Spot instance interruption

### DIFF
--- a/content/beginner/150_spotworkers/deployhandler.md
+++ b/content/beginner/150_spotworkers/deployhandler.md
@@ -12,7 +12,7 @@ We need `Helm` to deploy the `AWS Node Termination Handler`, see [installing Hel
  
 In this section, we will prepare our cluster to handle Spot interruptions.
 
-If the available On-Demand capacity of a particular instance type is deleted, the Spot Instance is sent an interruption notice two minutes ahead to gracefully wrap up things. We will deploy a pod on each spot instance to detect and redeploy applications elsewhere in the cluster.
+Demand for Spot Instances can vary significantly, and as a consequence the availability of Spot Instances will also vary depending on how many unused EC2 instances are available. It is always possible that your Spot Instance might be interrupted. In this case the Spot Instances are sent an interruption notice two minutes ahead to gracefully wrap up things. We will deploy a pod on each spot instance to detect and redeploy applications elsewhere in the cluster.
 
 The first thing that we need to do is deploy the [AWS Node Termination Handler](https://github.com/aws/aws-node-termination-handler) on each Spot Instance. This will monitor the EC2 metadata service on the instance for an interruption notice.
 The termination handler consists of a `ServiceAccount`, `ClusterRole`, `ClusterRoleBinding`, and a `DaemonSet`.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed wording on Spot instance interruption. The actual description falsely gives the impression that on On-Demand instances are being interrupted, while this is the case for Spot instances only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
