### PR TITLE
Correction of cluster tag use in the secondary CIDR section

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/cleanup.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/cleanup.md
@@ -37,7 +37,7 @@ Use caution before you run the next command because it terminates all worker nod
 {{% /notice %}}
 
 ```
-INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=eksworkshop*" --output text` )
+INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text` )
 for i in "${INSTANCE_IDS[@]}"
 do
 	echo "Terminating EC2 instance $i ..."

--- a/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
@@ -49,7 +49,7 @@ Use caution before you run the next command because it terminates all worker nod
 {{% /notice %}}
 
 ```
-INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=eksworkshop*" --output text` )
+INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text` )
 for i in "${INSTANCE_IDS[@]}"
 do
 	echo "Terminating EC2 instance $i ..."

--- a/content/beginner/160_advanced-networking/secondary_cidr/eniconfig_crd.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/eniconfig_crd.md
@@ -49,7 +49,7 @@ aws ec2 describe-subnets  --filters "Name=cidr-block,Values=100.64.*" --query 'S
 {{< /output >}}
 Check your Worker Node SecurityGroup
 ```
-INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag:Name,Values=eksworkshop*" --output text`)
+INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text`)
 for i in "${INSTANCE_IDS[@]}"
 do
   echo "SecurityGroup for EC2 instance $i ..."
@@ -88,7 +88,7 @@ Similarly, create custom resource **group3-pod-netconfig.yaml** for third subnet
 
 Check the instance details using this command as you will need AZ info when you apply annotation to Worker nodes using custom network config
 ```
-aws ec2 describe-instances --filters "Name=tag:Name,Values=eksworkshop*" --query 'Reservations[*].Instances[*].[PrivateDnsName,Tags[?Key==`Name`].Value|[0],Placement.AvailabilityZone,PrivateIpAddress,PublicIpAddress]' --output table   
+aws ec2 describe-instances --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --query 'Reservations[*].Instances[*].[PrivateDnsName,Tags[?Key==`eks:nodegroup-name`].Value|[0],Placement.AvailabilityZone,PrivateIpAddress,PublicIpAddress]' --output table  
 ```
 {{< output >}}
 ------------------------------------------------------------------------------------------------------------------------------------------

--- a/content/beginner/160_advanced-networking/secondary_cidr/prerequisites.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/prerequisites.md
@@ -21,7 +21,7 @@ aws ec2 associate-vpc-cidr-block --vpc-id $VPC_ID --cidr-block 100.64.0.0/16
 Next step is to create subnets. Before we do this step, let's check how many subnets we are consuming. You can run this command to see EC2 instance and AZ details
 
 ```
-aws ec2 describe-instances --filters "Name=tag:Name,Values=eksworkshop*" --query 'Reservations[*].Instances[*].[PrivateDnsName,Tags[?Key==`Name`].Value|[0],Placement.AvailabilityZone,PrivateIpAddress,PublicIpAddress]' --output table   
+aws ec2 describe-instances --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --query 'Reservations[*].Instances[*].[PrivateDnsName,Tags[?Key==`eks:nodegroup-name`].Value|[0],Placement.AvailabilityZone,PrivateIpAddress,PublicIpAddress]' --output table   
 ```
 {{< output >}}
 ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
"Using secondary CIDR in EKS" section refers to cluster instance tags with tag key "Name" while this tag is nonexistent. Query filters based on this tag do not return any result.

Changed the queries to use other tags which are configured initially during the deployment of the cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
