### PR TITLE
Flux section fixes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 languageCode = "en-us"
-ignoreFiles = [ "\\.files/README.md$",  ]
+ignoreFiles = [ "\\.files/README.md$",  "content/intermediate/260_weave_flux/app.files/"]
 defaultContentLanguage = "en"
 title = "Amazon EKS Workshop"
 theme = "learn"

--- a/content/intermediate/250_cloudwatch_container_insights/cwcinstall.md
+++ b/content/intermediate/250_cloudwatch_container_insights/cwcinstall.md
@@ -12,11 +12,11 @@ We'll be using the QuickStart to make the install simple and easy for the Contai
 You can find the full information and manual install steps here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html 
 
 
-From your Cloud9 Terminal you will just need to run the following command:
+From your Cloud9 Terminal you will just need to run the following command. Make sure to replace the region name placeholder `<AWS_REGION_NAME>` with the region name where the cluster has been deployed.
 
 
 ```
-curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/master/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml | sed "s/{{cluster_name}}/eksworkshop-eksctl/;s/{{region_name}}/us-east-2/" | kubectl apply -f -
+curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/master/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml | sed "s/{{cluster_name}}/eksworkshop-eksctl/;s/{{region_name}}/<AWS_REGION_NAME>/" | kubectl apply -f -
 ```
 
 With this quick start it will push the necessary daemon sets to collect the data for CloudWatch Containers Insights.

--- a/content/intermediate/260_weave_flux/codepipeline.md
+++ b/content/intermediate/260_weave_flux/codepipeline.md
@@ -20,7 +20,7 @@ Click the **Launch** button to create the CloudFormation stack in the AWS Manage
 | ------ |:------:|:--------:|
 | CodePipeline & EKS |  {{< cf-launch "weave_flux_pipeline.cfn.yml" "image-codepipeline" >}} | {{< cf-download "weave_flux_pipeline.cfn.yml" >}}  |
 
-After the console is open, enter your GitHub username, personal access token (created in previous step), check the acknowledge box and then click the "Create stack" button located at the bottom of the page.
+After the console is open, enter your GitHub username, personal access token (created in previous step) and then click the "Create stack" button located at the bottom of the page.
 
 ![CloudFormation Stack](/images/weave_flux/cloudformation_stack.png)
 

--- a/content/intermediate/260_weave_flux/installweaveflux.md
+++ b/content/intermediate/260_weave_flux/installweaveflux.md
@@ -63,7 +63,7 @@ kubectl get pods -n flux
 Install fluxctl in order to get the SSH key to allow GitHub write access.  This allows Flux to keep the configuration in GitHub in sync with the configuration deployed in the cluster.  
 
 ```
-sudo wget -O /usr/local/bin/fluxctl https://github.com/fluxcd/flux/releases/download/1.14.1/fluxctl_linux_amd64
+sudo wget -O /usr/local/bin/fluxctl $(curl https://api.github.com/repos/fluxcd/flux/releases/latest | jq -r ".assets[] | select(.name | test(\"linux_amd64\")) | .browser_download_url")
 sudo chmod 755 /usr/local/bin/fluxctl
 
 fluxctl version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes in the Flux section of the workshop:
-  Replace old version of hard-coded flux release with a placeholder for the latest official version.
- Remove "check the acknowledge box" instruction from as there is no "acknowledge box" to check in the new Stack creation screen.
- Clicking Next on the Cleanup page in Flux section will route you to the index.html of flux "Hello World" demo app, instead of moving to the next section in the Workshop. This is because Hugo will forward requests to all index files present in the workshop directories. In order to rectify this behavior we need to give Hugo a directive to ignore app files and not render them as part of the workshop. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
