### PR TITLE
Fix wrong component name

### DIFF
--- a/content/advanced/320_servicemesh_with_appmesh/create_app_mesh_components/about_sidecar.md
+++ b/content/advanced/320_servicemesh_with_appmesh/create_app_mesh_components/about_sidecar.md
@@ -14,4 +14,4 @@ This can be setup in few different ways:
 
 * After installing the deployment, we could patch the deployment to include the sidecar container specs.  Upon applying this patch, the old pods would be torn down, and the new pods would come up with the sidecar.
 
-* Finally, we can implement the `AWS App Mesh Controller`, which watches for new pods to be created, and automatically adds the sidecar data to the pods as they are deployed.
+* Finally, we can implement the `AWS App Mesh Sidecar Injector`, which watches for new pods to be created, and automatically adds the sidecar data to the pods as they are deployed.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The component which automatically adds the sidecar is not AWS App Mesh Controller but AWS App Mesh Sidecar Injector.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
