### PR TITLE
Update with the latest required permissions for 1.14/1.15 cluster

### DIFF
--- a/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
+++ b/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
@@ -41,11 +41,14 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["watch","list"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets","replicasets"]
+  resources: ["statefulsets","replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["watch","list","get"]
+- apiGroups: ["batch","extensions"]
+  resources: ["jobs"]
+  verbs: ["watch","list","get","patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -59,11 +62,11 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["create"]
+  verbs: ["create","list","watch"]
 - apiGroups: [""]
   resources: ["configmaps"]
-  resourceNames: ["cluster-autoscaler-status"]
-  verbs: ["delete","get","update"]
+  resourceNames: ["cluster-autoscaler-status","cluster-autoscaler-priority-expander"]
+  verbs: ["delete","get","update","watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
The following errors, for instance, are logged with the latest [cluster_autoscaler.yml](https://github.com/aws-samples/eks-workshop/blob/3c77d487689bff9aefaa621d0c5fa79c4e534b8e/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml) due to the lack of k8s RBAC permissions.

```
k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:330: Failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "jobs" in API group "batch" at the cluster scope
```

```
k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes/listers.go:312: Failed to list *v1.DaemonSet: daemonsets.apps is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "daemonsets" in API group "apps" at the cluster scope
```

This PR updates the cluster_autoscaler.yml with the latest examples picked from the CA repository for [1.14](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.14.7/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml) and [1.15](https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.15.5/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-one-asg.yaml).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
