### PR TITLE
Update deploy.md

### DIFF
--- a/content/beginner/060_helm/helm_micro/deploy.md
+++ b/content/beginner/060_helm/helm_micro/deploy.md
@@ -27,8 +27,7 @@ helm install workshop ~/environment/eksdemo
 ```
 
 Similar to what we saw previously in the [nginx Helm Chart
-example](/beginner/060_helm/helm_nginx/index.html), an output of the Deployment,
-Pod, and Service objects are output, similar to:
+example](/beginner/060_helm/helm_nginx/index.html), an output of the command will contain the information about the deployment status, revision, namespace, etc, similar to:
 
 {{< output >}}
 NAME: workshop
@@ -37,30 +36,9 @@ NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
-
-
-RESOURCES:
-==> v1/Service
-NAME              AGE
-ecsdemo-crystal   0s
-ecsdemo-frontend  0s
-ecsdemo-nodejs    0s
-
-==> v1/Deployment
-ecsdemo-crystal   0s
-ecsdemo-frontend  0s
-ecsdemo-nodejs    0s
-
-==> v1/Pod(related)
-
-NAME                               READY  STATUS             RESTARTS  AGE
-ecsdemo-crystal-764b9cb9bc-4dwqt   0/1    ContainerCreating  0         0s
-ecsdemo-crystal-764b9cb9bc-hcb62   0/1    ContainerCreating  0         0s
-ecsdemo-crystal-764b9cb9bc-vl7nr   0/1    ContainerCreating  0         0s
-ecsdemo-frontend-67876457f6-2xrtb  0/1    ContainerCreating  0         0s
-ecsdemo-frontend-67876457f6-bfnc5  0/1    ContainerCreating  0         0s
-ecsdemo-frontend-67876457f6-rb6rg  0/1    ContainerCreating  0         0s
-ecsdemo-nodejs-c458bf55d-994cq     0/1    ContainerCreating  0         0s
-ecsdemo-nodejs-c458bf55d-9qtbm     0/1    ContainerCreating  0         0s
-ecsdemo-nodejs-c458bf55d-s9zkh     0/1    ContainerCreating  0         0s
 {{< /output >}}
+
+In order to review the underlying services, pods and deployments, run:
+```sh
+kubectl get svc,po,deploy
+```


### PR DESCRIPTION
`Helm install` output changed and no longer includes details - updated the instructions and added `kubectl get svc,po,deploy` to review the underlying services

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
