### PR TITLE
Syntax error

### DIFF
--- a/content/advanced/320_servicemesh_with_appmesh/create_app_mesh_components/create_injector_controller.md
+++ b/content/advanced/320_servicemesh_with_appmesh/create_app_mesh_components/create_injector_controller.md
@@ -126,7 +126,7 @@ Finally we can verify that the mesh has been created:
 * Using the awscli
 
 ```bash
-aws appmesh list-meshes | jq '.meshes[].meshName'
+aws app mesh list-meshes | jq '.meshes[].meshName'
 ```
 
 {{< output >}}


### PR DESCRIPTION
Changed
aws appmesh list-meshes
To
aws app mesh list-meshes

As command was wrong and displayed a 403 error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
