### PR TITLE
Update token request to aws-iam-authenticator

### DIFF
--- a/content/beginner/040_dashboard/connect.md
+++ b/content/beginner/040_dashboard/connect.md
@@ -15,7 +15,7 @@ Now we can access the Kubernetes Dashboard
 
 Open a New Terminal Tab  and enter
 ```
-aws eks get-token --cluster-name eksworkshop-eksctl | jq -r '.status.token'
+aws-iam-authenticator token --cluster-id eksworkshop-eksctl | jq -r '.status.token'
 ```
 
 Copy the output of this command and then click the radio button next to


### PR DESCRIPTION
Command to request the token for logging into the Kubernetes dashboard needs to be updated to use the aws-iam-authenticator

*Issue #, if available:*
#740

*Description of changes:*
Update the shown command to be aws-iam-authenticator token instead of aws eks get-token

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
