### PR TITLE
added instructions for awscliv2 + minor edits

### DIFF
--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -20,7 +20,7 @@ sudo chmod +x /usr/local/bin/kubectl
 ```
 #### Update awscli
 
-Upgrade AWS CLI according to guidance in [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html).
+Upgrade AWS CLI according to guidance in [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html).
 
 ```
 sudo pip install --upgrade awscli

--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -20,12 +20,27 @@ sudo curl --silent --location -o /usr/local/bin/kubectl https://amazon-eks.s3-us
 
 sudo chmod +x /usr/local/bin/kubectl
 ```
-#### Install aws-iam-authenticator
+#### Update awscli-v2
+
+Upgrade AWS CLI version 2 according to guidance in [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html).
+
 ```
-sudo curl --silent --location -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
 
+sudo ./aws/install
+```
 
-sudo chmod +x /usr/local/bin/aws-iam-authenticator
+Add the AWS CLI version 2 to $PATH in `bash_profile`.
+
+```
+echo "export PATH='$PATH:/usr/local/bin/aws'" | tee -a ~/.bash_profile
+```
+
+Reload the `bash_profile`
+
+```
+source ~/.bash_profile
 ```
 
 #### Install jq, envsubst (from GNU gettext utilities) and bash-completion
@@ -35,7 +50,7 @@ sudo yum -y install jq gettext bash-completion
 
 #### Verify the binaries are in the path and executable
 ```
-for command in kubectl jq envsubst
+for command in kubectl jq envsubst aws
   do
     which $command &>/dev/null && echo "$command in path" || echo "$command NOT FOUND"
   done

--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -15,32 +15,15 @@ for the download links.](https://docs.aws.amazon.com/eks/latest/userguide/gettin
 
 #### Install kubectl
 ```
-sudo curl --silent --location -o /usr/local/bin/kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
-
-
+sudo curl --silent --location -o /usr/local/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/kubectl
 sudo chmod +x /usr/local/bin/kubectl
 ```
-#### Update awscli-v2
+#### Update awscli
 
-Upgrade AWS CLI version 2 according to guidance in [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html).
-
-```
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-
-sudo ./aws/install
-```
-
-Add the AWS CLI version 2 to $PATH in `bash_profile`.
+Upgrade AWS CLI according to guidance in [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html).
 
 ```
-echo "export PATH='$PATH:/usr/local/bin/aws'" | tee -a ~/.bash_profile
-```
-
-Reload the `bash_profile`
-
-```
-source ~/.bash_profile
+sudo pip install --upgrade awscli
 ```
 
 #### Install jq, envsubst (from GNU gettext utilities) and bash-completion

--- a/content/beginner/040_dashboard/connect.md
+++ b/content/beginner/040_dashboard/connect.md
@@ -18,10 +18,6 @@ Open a New Terminal Tab  and enter
 aws eks get-token --cluster-name eksworkshop-eksctl | jq -r '.status.token'
 ```
 
-{{% notice info %}}
-If you stumble upon an error here, you might be running an older version of the AWS CLI. Please follow the instructions here to update to a more recent version of the AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
-{{% /notice %}}
-
 Copy the output of this command and then click the radio button next to
 *Token* then in the text field below paste the output from the last command.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added instructions for AWS CLI v2 updates in 'Start the workshop > Install Kubernetes Tools'. Cloud9 was being built using older AWS CLI version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
