### PR TITLE
Update cleanup.md

### DIFF
--- a/content/beginner/090_rbac/cleanup.md
+++ b/content/beginner/090_rbac/cleanup.md
@@ -16,4 +16,5 @@ rm rbacuser_creds.sh
 rm /tmp/create_output.json
 rm rbacuser-role.yaml
 rm rbacuser-role-binding.yaml
+aws iam delete-user --user-name rbac-user
 ```


### PR DESCRIPTION
Added deletion of IAM user "rbac-user" from AWS

The 'cleanup' wasn't complete, as the "rbac-user" which had been created at the start of this module, wasn't deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
