### PR TITLE
changed the docker images base url

### DIFF
--- a/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
+++ b/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
@@ -123,7 +123,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v${AUTOSCALER_VERSION}
+        - image: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v${AUTOSCALER_VERSION}
           name: cluster-autoscaler
           resources:
             limits:

--- a/content/beginner/080_scaling/test_hpa.md
+++ b/content/beginner/080_scaling/test_hpa.md
@@ -9,7 +9,7 @@ weight: 20
 We will deploy an application and expose as a service on TCP port 80. The application is a custom-built image based on the php-apache image. The index.php page performs calculations to generate CPU load. More information can be found [here](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#run-expose-php-apache-server)
 
 ```
-kubectl run php-apache --image=k8s.gcr.io/hpa-example --requests=cpu=200m --expose --port=80
+kubectl run php-apache --image=us.gcr.io/k8s-artifacts-prod/hpa-example --requests=cpu=200m --expose --port=80
 ```
 
 ### Create an HPA resource

--- a/content/beginner/140_assigning_pods/affinity.md
+++ b/content/beginner/140_assigning_pods/affinity.md
@@ -60,7 +60,7 @@ spec:
             - another-node-label-value
   containers:
   - name: with-node-affinity
-    image: k8s.gcr.io/pause:2.0
+    image: us.gcr.io/k8s-artifacts-prod/pause:2.0
 EoF
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The k8s.gcr.io name is currently a facade for gcr.io/google-containers, which is only writeable by Google employees.

Changing the base url of docker images to point to the right repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
