### PR TITLE
bump istio version to 1.5.1 due to CVE-2020-1764

### DIFF
--- a/content/advanced/310_servicemesh_with_istio/download.md
+++ b/content/advanced/310_servicemesh_with_istio/download.md
@@ -8,11 +8,11 @@ draft: false
 Before we can get started configuring Istio we’ll need to first install the command line tools that you will interact with. To do this run the following.
 
 {{% notice info %}}
-We will use istio version `1.5.0`
+We will use istio version `1.5.1`
 {{% /notice %}}
 
 ```bash
-echo 'export ISTIO_VERSION="1.5.0"' >> ${HOME}/.bash_profile
+echo 'export ISTIO_VERSION="1.5.1"' >> ${HOME}/.bash_profile
 source ${HOME}/.bash_profile
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
istio 1.5.1 release contains bug fixes to improve robustness and fixes for the security vulnerabilities described in https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1764
*Description of changes:*
Bump version from 1.5.0 to 1.5.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
