### PR TITLE
Fix failed delete-user due to existing access key

### DIFF
--- a/content/beginner/090_rbac/cleanup.md
+++ b/content/beginner/090_rbac/cleanup.md
@@ -13,8 +13,9 @@ unset AWS_ACCESS_KEY_ID
 kubectl delete namespace rbac-test
 rm aws-auth.yaml
 rm rbacuser_creds.sh
-rm /tmp/create_output.json
 rm rbacuser-role.yaml
 rm rbacuser-role-binding.yaml
+aws iam delete-access-key --user-name=rbac-user --access-key-id=$(jq -r .AccessKey.AccessKeyId /tmp/create_output.json)
 aws iam delete-user --user-name rbac-user
+rm /tmp/create_output.json
 ```


### PR DESCRIPTION
*Description of changes:*
Fix failed delete-user due to existing AWS-Access-Key, when executing aws iam delete-user 
by deleting the access key first (and lastly removing the saved credentials)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
