### PR TITLE
Fix failed delete of iam users due to wrong key id

### DIFF
--- a/content/beginner/091_iam-groups/cleanup.md
+++ b/content/beginner/091_iam-groups/cleanup.md
@@ -29,9 +29,9 @@ aws iam delete-group --group-name k8sAdmin
 aws iam delete-group --group-name k8sDev
 aws iam delete-group --group-name k8sInteg
 
-aws iam delete-access-key --user-name PaulAdmin --access-key-id=$(jq -r .AccessKey.SecretAccessKey /tmp/PaulAdmin.json)
-aws iam delete-access-key --user-name JeanDev --access-key-id=$(jq -r .AccessKey.SecretAccessKey /tmp/JeanDev.json)
-aws iam delete-access-key --user-name PierreInteg --access-key-id=$(jq -r .AccessKey.SecretAccessKey /tmp/PierreInteg.json)
+aws iam delete-access-key --user-name PaulAdmin --access-key-id=$(jq -r .AccessKey.AccessKeyId /tmp/PaulAdmin.json)
+aws iam delete-access-key --user-name JeanDev --access-key-id=$(jq -r .AccessKey.AccessKeyId /tmp/JeanDev.json)
+aws iam delete-access-key --user-name PierreInteg --access-key-id=$(jq -r .AccessKey.AccessKeyId /tmp/PierreInteg.json)
 
 aws iam delete-user --user-name PaulAdmin
 aws iam delete-user --user-name JeanDev


### PR DESCRIPTION
*Issue*

When tying to delete the access keys for the generated user, the secret is referenced instead of the key id, thus the delete fails and subsequently also the removal of the users.

*Description of changes:*
Changed to reference key ids.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
