### PR TITLE
Remove manual region configuration for Cluster Autoscaler

### DIFF
--- a/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
+++ b/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
@@ -141,7 +141,7 @@ spec:
             - --nodes=2:8:<AUTOSCALING GROUP NAME>
           env:
             - name: AWS_REGION
-              value: <AWS_REGION_NAME>
+              value: ${AWS_REGION}
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs/ca-certificates.crt

--- a/content/beginner/080_scaling/deploy_ca.md
+++ b/content/beginner/080_scaling/deploy_ca.md
@@ -49,7 +49,7 @@ Click `Save`
 
 Using the file browser on the left, open cluster_autoscaler.yml
 
-Search for `command:` and within this block, replace the placeholder text `<AUTOSCALING GROUP NAME>` with the ASG name that you copied in the previous step. Also, insert the **AWS_REGION** value by replacing the `<AWS_REGION_NAME>` placeholder to reflect the region you are using and **Save** the file.
+Search for `command:` and within this block, replace the placeholder text `<AUTOSCALING GROUP NAME>` with the ASG name that you copied in the previous step.
 
 {{< output >}}
 command:
@@ -59,9 +59,6 @@ command:
   - --cloud-provider=aws
   - --skip-nodes-with-local-storage=false
   - --nodes=2:8:eksctl-eksworkshop-eksctl-nodegroup-0-NodeGroup-SQG8QDVSR73G
-env:
-  - name: AWS_REGION
-    value: us-east-1
 {{< /output >}}
 This command contains all of the configuration for the Cluster Autoscaler. The primary config is the `--nodes` flag. This specifies the minimum nodes **(2)**, max nodes **(8)** and **ASG Name**.
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* During the deployment of the Cluster Autoscaler, we ask people to manually edit the region into the YAML manifest. However, as part of the same step, the YAML manifest is processed with `envsubst`. Since the region is already available as an environment variable [1], we can update the YAML manifest so that the region gets replaced as well when running `envsubst`.

[1] https://eksworkshop.com/020_prerequisites/workspaceiam/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.