### PR TITLE
Adding new EKS Fargate regions to warning

### DIFF
--- a/content/beginner/180_fargate/prerequisites.md
+++ b/content/beginner/180_fargate/prerequisites.md
@@ -9,20 +9,25 @@ AWS Fargate with Amazon EKS is currently only available in the following Regions
 
 | Region Name | Region |
 |---|---|
-| US East (Ohio) | us-east-2 |
 | US East (N. Virginia) | us-east-1 |
+| US East (Ohio) | us-east 2 |
+| US West (Oregon) | us-west-2 |
+| Europe (Ireland) | eu-west-1 |
+| Europe (Frankfurt) | eu-central-1 |
+| Asia Pacific (Singapore) | ap-southeast-1 |
+| Asia Pacific (Sydney) | ap-southeast-2 |
 | Asia Pacific (Tokyo) | ap-northeast-1 |
-| EU (Ireland) | eu-west-1 |
 
 Run this command to verify if AWS Fargate with Amazon EKS is available in the Region you choose to deploy your Amazon EKS cluster.
 
 ```bash
-if [ $AWS_REGION = "us-east-1" ] || [ $AWS_REGION = "us-east-2" ] || [ $AWS_REGION = "ap-northeast-1" ] || [ $AWS_REGION = "eu-west-1" ] ; then
+if [[ $AWS_REGION =~ ^(us-east-1|us-east 2|us-west-2|eu-west-1|eu-central-1|ap-southeast-1|ap-southeast-2|ap-northeast-1)$ ]]
+; then
   echo -e "\033[0;32mAWS Fargate with Amazon EKS is available in your Region."
   echo "You can continue this lab."
 else
-  echo -e "\033[0;31mAWS Fargate with Amazon EKS is not yet available in your Region."
-  echo "Deploy your cluster in one of the Regions mentioned above"
+  echo -e "\033[0;31mAWS Fargate with Amazon EKS is not yet available in your Region ($AWS_REGION)."
+  echo "Deploy your cluster in one of the Regions mentioned above."
 fi
 ```
 


### PR DESCRIPTION
Also, on Cloud9 using the included GNU bash 4.2, the above script threw a "[: =: unary operator expected" error, so that's fixed now as well.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
