### PR TITLE
Fix broken file path in Istio workshop module instructions

### DIFF
--- a/content/advanced/310_servicemesh_with_istio/routing.md
+++ b/content/advanced/310_servicemesh_with_istio/routing.md
@@ -238,7 +238,7 @@ To test it, refresh your browser over and over, and you'll see only reviews:v1 a
 Assuming you decide tat the `reviews:v3` microservice is stable, you can route 100% of the traffic to it
 
 ```bash
-kubectl -n bookinfo apply -f samples/bookinfo/networking/virtual-service-reviews-v3.yaml
+kubectl -n bookinfo apply -f ${HOME}/environment/istio-${ISTIO_VERSION}/samples/bookinfo/networking/virtual-service-reviews-v3.yaml
 ```
 
 Now when you refresh the `/productpage` you will always see `reviews:v3` (red colored star ratings).


### PR DESCRIPTION
Prepend the correct path so that users do not receive an error when copy/pasting the last instruction to apply virtual-service-reviews-v3.yaml

*Issue #, if available:*
When users copy/paste the last command, they receive an error because the path is not complete.

*Description of changes:*
Update to the command to prepend the correct file path for the kubectl apply command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
