### PR TITLE
fix typo in a cleanup command on "Using IAM Groups to manage Kubernetes"

### DIFF
--- a/content/beginner/091_iam-groups/cleanup.md
+++ b/content/beginner/091_iam-groups/cleanup.md
@@ -10,7 +10,7 @@ Once you have completed this chapter, you can cleanup the files and resources yo
 ```bash
 unset KUBECONFIG
 
-kubectl delete namespace development integration$
+kubectl delete namespace development integration
 kubectl delete pod nginx-admin
 
 eksctl delete iamidentitymapping --cluster eksworkshop-eksctl --arn arn:aws:iam::${ACCOUNT_ID}:role/k8sAdmin


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:* I found an unnecessary dollar sign (`$`) in a cleanup command in the `Amazon EKS Workshop > Beginner > Using IAM Groups to manage Kubernetes` section [CLEANUP page](https://eksworkshop.com/beginner/091_iam-groups/cleanup/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.