### PR TITLE
Update the CNI to v1.6.1

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
@@ -13,9 +13,9 @@ kubectl describe daemonset aws-node --namespace kube-system | grep Image | cut -
 ```
 Here is a sample response
 {{< output >}}
-amazon-k8s-cni:1.5.7
+amazon-k8s-cni:1.6.1
 {{< /output >}}
-Upgrade to the latest v1.5 config if you have an older version:
+Upgrade to the latest v1.6 config if you have an older version:
 ```
 kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.5/aws-k8s-cni.yaml
 ```


### PR DESCRIPTION
*Description of changes:*

CNI v1.6.1 is the latest release and default for new clusters now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
