### PR TITLE
Use latest version of kubernetes dashboard

### DIFF
--- a/content/beginner/040_dashboard/dashboard.md
+++ b/content/beginner/040_dashboard/dashboard.md
@@ -9,17 +9,17 @@ instructions in [the official documentation](https://kubernetes.io/docs/tasks/ac
 
 We can deploy the dashboard with the following command:
 ```
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0/aio/deploy/recommended.yaml
 ```
 
 Since this is deployed to our private cluster, we need to access it via a proxy.
 Kube-proxy is available to proxy our requests to the dashboard service.  In your
 workspace, run the following command:
 ```
-kubectl proxy --port=8080 --address='0.0.0.0' --disable-filter=true &
+kubectl proxy --port=8001 --address=0.0.0.0 --disable-filter=true &
 ```
 
-This will start the proxy, listen on port 8080, listen on all interfaces, and
+This will start the proxy, listen on port 8001, listen on all interfaces, and
 will disable the filtering of non-localhost requests.
 
 This command will continue to run in the background of the current terminal's session.


### PR DESCRIPTION
Dashboard version 1.10 generating error 404 when connecting.  Update dashboard to version 2

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
