### PR TITLE
change the VPC CNI version in command v1.5 -> v1.6

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
@@ -17,7 +17,7 @@ amazon-k8s-cni:1.6.1
 {{< /output >}}
 Upgrade to the latest v1.6 config if you have an older version:
 ```
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.5/aws-k8s-cni.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.6/aws-k8s-cni.yaml
 ```
 Wait until all the pods are recycled. You can check the status of pods by using this command
 ```


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

To upgrade to the latest v1.6 as stated in the description, you need to apply manifest under the "v1.6" directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
