### PR TITLE
Get existing configMap - then apply rbac-user

### DIFF
--- a/content/beginner/090_rbac/map_iam_user_to_k8s_user.md
+++ b/content/beginner/090_rbac/map_iam_user_to_k8s_user.md
@@ -5,15 +5,14 @@ draft: false
 weight: 30
 ---
 
-Next, we'll define a k8s user called rbac-user, and map to it's IAM user counterpart.  Run the following to create a ConfigMap called aws-auth.yaml that creates this mapping:
+Next, we'll define a k8s user called rbac-user, and map to it's IAM user counterpart.  Run the following to get the existing ConfigMap and save into a file called aws-auth.yaml:
+```
+kubectl get configmap -n kube-system aws-auth -o yaml > aws-auth.yaml
+```
+Next append the rbac-user mapping to the existing configMap
 
 ```
-cat << EoF > aws-auth.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: aws-auth
-  namespace: kube-system
+cat << EoF >> aws-auth.yaml
 data:
   mapUsers: |
     - userarn: arn:aws:iam::${ACCOUNT_ID}:user/rbac-user


### PR DESCRIPTION
*Issue #, if available:*

AS it stands the instructions will leave you unable to access the cluster with kubectl after creating the RBAC user

*Description of changes:*

Get the existing configMap - which should exist as we just created the cluster.
Append the mapping for the rbac-user to the existing aws-auth configMap
And apply.

This leave the original access intact -and adds the rbac-user which I think was probably the original intent for this section

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
