### PR TITLE
Update routing.md

### DIFF
--- a/content/advanced/310_servicemesh_with_istio/routing.md
+++ b/content/advanced/310_servicemesh_with_istio/routing.md
@@ -36,7 +36,7 @@ kubectl -n bookinfo \
 We can display the virtual service with the following command.
 
 ```bash
-kubectl -n bookinfo get virtualservices reviews -o yaml
+kubectl -n bookinfo get virtualservices bookinfo -o yaml
 ```
 
 The subset is set to v1 for all reviews request.


### PR DESCRIPTION
display the virtual service should point to `bookinfo` and not `reviews`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
