### PR TITLE
Fix: now eksctl uses aws-iam-authenticator and no more aws get-token

### DIFF
--- a/content/beginner/091_iam-groups/test-cluster-access.md
+++ b/content/beginner/091_iam-groups/test-cluster-access.md
@@ -93,10 +93,10 @@ Create new KUBECONFIG file to test this:
 
 ```
 export KUBECONFIG=/tmp/kubeconfig-dev && eksctl utils write-kubeconfig eksworkshop-eksctl
-cat $KUBECONFIG | awk "/args:/{print;print \"      - --profile\n      - dev\";next}1" | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-dev./g' | tee $KUBECONFIG
+cat $KUBECONFIG | awk "/env:/{print;print \"      - name: AWS_PROFILE\n        value: dev\";next}1" | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-dev./g' | tee $KUBECONFIG
 ```
 
-We just added the `--profile dev` parameter to our kubectl config file, so that this will ask kubectl to use our IAM role associated to our dev profile.
+We just added the `AWS_PROFILE: dev` environment variable to our kubectl config file, so that this will ask kubectl to use our IAM role associated to our dev profile.
 
 With this configuration we should be able to interract with the **development** namespace, because it as our RBAC role defined.
 
@@ -130,7 +130,7 @@ Error from server (Forbidden): pods is forbidden: User "dev-user" cannot list re
 
 ```
 export KUBECONFIG=/tmp/kubeconfig-integ && eksctl utils write-kubeconfig eksworkshop-eksctl
-cat $KUBECONFIG | awk "/args:/{print;print \"      - --profile\n      - integ\";next}1" | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-integ./g' | tee $KUBECONFIG
+cat $KUBECONFIG | awk "/env:/{print;print \"      - name: AWS_PROFILE\n        value: integ\";next}1" | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-integ./g' | tee $KUBECONFIG
 ```
 
 let's create a pod
@@ -165,6 +165,7 @@ Error from server (Forbidden): pods is forbidden: User "integ-user" cannot list 
 ```
 export KUBECONFIG=/tmp/kubeconfig-admin && eksctl utils write-kubeconfig eksworkshop-eksctl
 cat $KUBECONFIG | awk "/args:/{print;print \"      - --profile\n      - admin\";next}1" | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-admin./g' | tee $KUBECONFIG
+cat $KUBECONFIG | awk "/env:/{print;print \"      - name: AWS_PROFILE\n        value: admin\";next}1" | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-admin./g' | tee $KUBECONFIG
 ```
 
 let's create a pod in default namespace


### PR DESCRIPTION
--profile option only woirks with aws get-token and not with aws-iam-authenticator

*Description of changes:*
Change the regexp to update kubeconfig file with AWS_PROFILE instead of --profile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
