### PR TITLE
force ALB to be in IP mode for fargate

### DIFF
--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -31,6 +31,14 @@ sudo pip install --upgrade awscli && hash -r
 sudo yum -y install jq gettext bash-completion
 ```
 
+#### Install yq for yaml processing
+
+```
+echo 'yq() {
+  docker run --rm -i -v "${PWD}":/workdir mikefarah/yq yq "$@"
+}' | tee -a ~/.bashrc && source ~/.bashrc
+```
+
 #### Verify the binaries are in the path and executable
 ```
 for command in kubectl jq envsubst aws

--- a/content/beginner/180_fargate/ingress.md
+++ b/content/beginner/180_fargate/ingress.md
@@ -7,10 +7,12 @@ draft: false
 
 #### Ingress
 
-The final step in exposing the 2048-game service is to deploy an ingress.
+The final step in exposing the 2048-game service through an ingress object. As we target Farget pods ip and not an ec2 instance, we add an annotation to the ingress to specify the target-type.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/${ALB_INGRESS_VERSION}/docs/examples/2048/2048-ingress.yaml
+wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/${ALB_INGRESS_VERSION}/docs/examples/2048/2048-ingress.yaml
+cat 2048-ingress.yaml | awk "/annotations:/{print;print \"    alb.ingress.kubernetes.io/target-type: ip\";next}1" | tee 2048-ingress.yaml.v2 ; mv 2048-ingress.yaml.v2 2048-ingress.yaml
+kubectl apply -f 2048-ingress.yaml
 ```
 
 This will start provisioning an instance of Internet-facing Application Load Balancer. From your AWS Management Console, if you navigate to the EC2 dashboard and the select **Load Balancers** from the menu on the left-pane, you should see the details of the ALB instance similar to the following.

--- a/content/beginner/180_fargate/ingress.md
+++ b/content/beginner/180_fargate/ingress.md
@@ -11,7 +11,7 @@ The final step in exposing the 2048-game service through an ingress object. As w
 
 ```bash
 wget https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/${ALB_INGRESS_VERSION}/docs/examples/2048/2048-ingress.yaml
-cat 2048-ingress.yaml | awk "/annotations:/{print;print \"    alb.ingress.kubernetes.io/target-type: ip\";next}1" | tee 2048-ingress.yaml.v2 ; mv 2048-ingress.yaml.v2 2048-ingress.yaml
+yq w -i 2048-ingress.yaml 'metadata.annotations."alb.ingress.kubernetes.io/target-type"' ip
 kubectl apply -f 2048-ingress.yaml
 ```
 


### PR DESCRIPTION

*Description of changes:*

This changes add an annotation so that the ALB is created in IP mode.
Actually it was default to be created in instance mode and did not works on a fargate only cluster, and was not according to the following explication saying it must be using fargate ip as target which was not the case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
