### PR TITLE
adding csinodes to CA rbac - fixes #806

### DIFF
--- a/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
+++ b/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
@@ -44,7 +44,7 @@ rules:
   resources: ["statefulsets","replicasets","daemonsets"]
   verbs: ["watch","list","get"]
 - apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses"]
+  resources: ["storageclasses", "csinodes"]
   verbs: ["watch","list","get"]
 - apiGroups: ["batch","extensions"]
   resources: ["jobs"]


### PR DESCRIPTION
fixes #806 -- error in the cluster_autoscaler due to missing permission to read csi in the RBAC rules.
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
