### PR TITLE
ALB ingress logs egprep command invalid

### DIFF
--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -50,7 +50,7 @@ kubectl apply -f alb-ingress-controller.yaml
 ```
 Verify that the deployment was successful and the controller started:
 ```
-kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o alb-ingress[a-zA-Z0-9-]+)
+kubectl logs -n kube-system $(kubectl get po -n kube-system | grep alb-ingress | awk '{print $1}')
 ```
 You should be able to see the following output:
 {{< output >}}


### PR DESCRIPTION
*Issue #, if available:*

egrep command does not work, as the name is alb-ingress-controller-xxxx, and regex invalid.

```
kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o alb-ingress[a-zA-Z0-9-]+)
```

*Description of changes:*

Simpler like this (at least it works...):
```
kubectl logs -n kube-system $(kubectl get po -n kube-system | grep alb-ingress | awk '{print $1}')
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
