### PR TITLE
Deprecated APIs Removed In 1.16: DaemonSet in the extensions/v1beta1 and apps/v1beta2 API

### DIFF
--- a/content/advanced/410_batch/cleanup.md
+++ b/content/advanced/410_batch/cleanup.md
@@ -22,7 +22,7 @@ aws s3 rb s3://batch-artifact-repository-${ACCOUNT_ID}/ --force
 #### Undeploy Argo
 
 ```bash
-kubectl delete -n argo -f https://raw.githubusercontent.com/argoproj/argo/v2.2.1/manifests/install.yaml
+kubectl delete -n argo -f https://raw.githubusercontent.com/argoproj/argo/v2.8.2/manifests/install.yaml
 kubectl delete namespace argo
 ```
 

--- a/content/advanced/410_batch/deploy.md
+++ b/content/advanced/410_batch/deploy.md
@@ -13,7 +13,7 @@ Deploy the Controller and UI.
 
 ```bash
 kubectl create namespace argo
-kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/v2.2.1/manifests/install.yaml
+kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/v2.8.2/manifests/install.yaml
 ```
 
 {{< output >}}

--- a/content/advanced/410_batch/install.md
+++ b/content/advanced/410_batch/install.md
@@ -11,7 +11,7 @@ Before we can get started configuring `argo` we'll need to first install the
 command line tools that you will interact with. To do this run the following.
 
 ```
-sudo curl -sSL -o /usr/local/bin/argo https://github.com/argoproj/argo/releases/download/v2.2.1/argo-linux-amd64
+sudo curl -sSL -o /usr/local/bin/argo https://github.com/argoproj/argo/releases/download/v2.8.2/argo-linux-amd64 
 sudo chmod +x /usr/local/bin/argo
 ```
 


### PR DESCRIPTION
Deprecated APIs Removed In 1.16:

Deployment in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 API versions is no longer served
Migrate to use the apps/v1 API version, available since v1.9. Existing persisted data can be retrieved/updated via the new version.


*Issue #, if available:* https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

*Description of changes:* changed argo v2.2.1 to v2.8.2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
