### PR TITLE
github master->main rename broke some download url's

### DIFF
--- a/content/beginner/170_statefulset/ebs_csi_driver.md
+++ b/content/beginner/170_statefulset/ebs_csi_driver.md
@@ -60,7 +60,7 @@ First, we'll need to download a few files.  Run:
 ```sh
 cd ~/environment/ebs_csi_driver
 for file in kustomization.yml deployment.yml attacher-binding.yml provisioner-binding.yml; do
-  curl -sSLO https://raw.githubusercontent.com/aws-samples/eks-workshop/master/content/beginner/170_statefulset/ebs_csi_driver.files/$file
+  curl -sSLO https://raw.githubusercontent.com/aws-samples/eks-workshop/main/content/beginner/170_statefulset/ebs_csi_driver.files/$file
 done
 ```
 

--- a/content/intermediate/260_weave_flux/codepipeline.md
+++ b/content/intermediate/260_weave_flux/codepipeline.md
@@ -47,8 +47,8 @@ Next create a base README file, a source directory, and download a sample nginx 
 ```
 echo "# eks-example" > README.md
 mkdir src
-wget -O src/hello.conf https://eksworkshop.com/intermediate/260_weave_flux/app.files/hello.conf
-wget -O src/index.html https://eksworkshop.com/intermediate/260_weave_flux/app.files/index.html
+wget -O src/hello.conf https://raw.githubusercontent.com/aws-samples/eks-workshop/main/content/intermediate/260_weave_flux/app.files/hello.conf
+wget -O src/index.html https://raw.githubusercontent.com/aws-samples/eks-workshop/main/content/intermediate/260_weave_flux/app.files/index.html
 wget https://raw.githubusercontent.com/aws-samples/eks-workshop/main/content/intermediate/260_weave_flux/app.files/Dockerfile
 ```
 

--- a/content/intermediate/260_weave_flux/codepipeline.md
+++ b/content/intermediate/260_weave_flux/codepipeline.md
@@ -49,7 +49,7 @@ echo "# eks-example" > README.md
 mkdir src
 wget -O src/hello.conf https://eksworkshop.com/intermediate/260_weave_flux/app.files/hello.conf
 wget -O src/index.html https://eksworkshop.com/intermediate/260_weave_flux/app.files/index.html
-wget https://raw.githubusercontent.com/aws-samples/eks-workshop/master/content/intermediate/260_weave_flux/app.files/Dockerfile
+wget https://raw.githubusercontent.com/aws-samples/eks-workshop/main/content/intermediate/260_weave_flux/app.files/Dockerfile
 ```
 
 Now that we have a simple hello world app, commit the changes to start the image build pipeline.  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
github master->main rename broke some download url's.
Noticed it in the weave flux section, but corrected other occurrences I found as well

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
