### PR TITLE
Updating patch for ebs-csi-controller deployment

### DIFF
--- a/content/beginner/170_statefulset/ebs_csi_driver.files/deployment.yml
+++ b/content/beginner/170_statefulset/ebs_csi_driver.files/deployment.yml
@@ -1,3 +1,3 @@
 - op: replace
-  path: /spec/template/spec/serviceAccount
+  path: /spec/template/spec/serviceAccountName
   value: ebs-csi-controller-irsa


### PR DESCRIPTION
The previous patch file had no effect and thus the deployment was still configured to use the default ebs-csi-controller-sa service account.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
