### PR TITLE
Parse subnets into array

### DIFF
--- a/content/beginner/190_efs/launching-efs.md
+++ b/content/beginner/190_efs/launching-efs.md
@@ -38,7 +38,7 @@ The following set of commands identifies the public subnets in your cluster VPC 
 ```
 TAG1=tag:kubernetes.io/cluster/$CLUSTER_NAME
 TAG2=tag:kubernetes.io/role/elb
-subnets=$(aws ec2 describe-subnets --filters "Name=$TAG1,Values=shared" "Name=$TAG2,Values=1" | jq --raw-output '.Subnets[].SubnetId')
+subnets=($(aws ec2 describe-subnets --filters "Name=$TAG1,Values=shared" "Name=$TAG2,Values=1" | jq --raw-output '.Subnets[].SubnetId'))
 for subnet in ${subnets[@]}
 do
     echo "creating mount target in " $subnet


### PR DESCRIPTION
previously, it fails to parse each component from the array with error: 
```
❯ for subnet in ${subnets[@]}
do
    echo "creating mount target in " $subnet
    aws efs create-mount-target --file-system-id $FILE_SYSTEM_ID --subnet-id $subnet --security-groups $MOUNT_TARGET_GROUP_ID
done
creating mount target in  subnet-aaa
subnet-bbb
subnet-ccc

An error occurred (ValidationException) when calling the CreateMountTarget operation: 2 validation errors detected: Value 'subnet-aaa
subnet-bbb
subnet-ccc' at 'subnetId' failed to satisfy constraint: Member must have length less than or equal to 47; Value 'subnet-aaa
subnet-bbb
subnet-ccc' at 'subnetId' failed to satisfy constraint: Member must satisfy regular expression pattern: ^subnet-[0-9a-f]{8,40}$
```
Previously, 
```
❯ echo $subnets
subnet-aaa...
subnet-bbb...
subnet-ccc....
```

After changes,
```
❯ echo $subnets
subnet-aaa..... subnet-bbb.... subnet-ccc....
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
