### PR TITLE
Update X-Ray lab to use IAM roles for service accounts

### DIFF
--- a/content/intermediate/245_x-ray/cleanup.md
+++ b/content/intermediate/245_x-ray/cleanup.md
@@ -25,6 +25,7 @@ Delete the X-Ray DaemonSet:
 kubectl delete -f https://eksworkshop.com/intermediate/245_x-ray/daemonset.files/xray-k8s-daemonset.yaml
 ```
 
+Delete the IAM Service Account:
 ```
-aws iam detach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+eksctl delete iamserviceaccount --name xray-daemon --cluster eksworkshop-eksctl
 ```

--- a/content/intermediate/245_x-ray/daemonset.files/Dockerfile
+++ b/content/intermediate/245_x-ray/daemonset.files/Dockerfile
@@ -1,12 +1,16 @@
 FROM amazonlinux:2
 
-# Download latest 3.x release of X-Ray daemon
+# Download latest 3.x release of X-Ray daemon and AWS CLI 2
 RUN yum install -y unzip && \
     cd /tmp/ && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
     curl https://s3.dualstack.us-east-2.amazonaws.com/aws-xray-assets.us-east-2/xray-daemon/aws-xray-daemon-linux-3.x.zip > aws-xray-daemon-linux-3.x.zip && \
     unzip aws-xray-daemon-linux-3.x.zip && \
     cp xray /usr/bin/xray && \
     rm aws-xray-daemon-linux-3.x.zip && \
+    rm awscliv2.zip && \
     rm cfg.yaml
 
 EXPOSE 2000/udp

--- a/content/intermediate/245_x-ray/daemonset.files/build.sh
+++ b/content/intermediate/245_x-ray/daemonset.files/build.sh
@@ -2,7 +2,7 @@
 
 TAG=$(git log -1 --pretty=%H)
 
-REPOSITORY=rnzdocker1/eks-workshop-x-ray-daemon
+REPOSITORY=trevorrobertsjr/eks-workshop-x-ray-daemon
 
 docker build --tag $REPOSITORY:$TAG .
 

--- a/content/intermediate/245_x-ray/daemonset.files/xray-k8s-daemonset.yaml
+++ b/content/intermediate/245_x-ray/daemonset.files/xray-k8s-daemonset.yaml
@@ -11,14 +11,6 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app: xray-daemon
-  name: xray-daemon
-  namespace: default
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -54,9 +46,10 @@ spec:
         configMap:
           name: xray-config
       hostNetwork: true
+      serviceAccountName: xray-daemon
       containers:
       - name: xray-daemon
-        image: rnzdocker1/eks-workshop-x-ray-daemon:dbada4c77e6ae10ecf5a7b1c5864aa6522d9fb02
+        image: trevorrobertsjr/eks-workshop-x-ray-daemon:02d13ce10add55081c68b6b76a19b7dfeea00dad
         imagePullPolicy: Always
         command: [ "/usr/bin/xray", "-c", "/aws/xray/config.yaml" ]
         resources:

--- a/content/intermediate/245_x-ray/role.md
+++ b/content/intermediate/245_x-ray/role.md
@@ -6,27 +6,20 @@ draft: false
 ---
 
 In order for the [X-Ray daemon](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon.html) 
-to communicate with the service, we need to add a policy to the worker nodes' 
-[AWS Identity and Access Management](https://aws.amazon.com/iam/) (IAM) role.
+to communicate with the service, we need to create a Kubernetes [service account](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) and attach an [AWS Identity and Access Management](https://aws.amazon.com/iam/) (IAM) role and policy with sufficient permissions.
 
-First, we will need to ensure the Role Name our workers use is set in our environment:
+{{% notice warning %}}
+If you have not completed the [IAM Roles for Service Accounts](https://www.eksworkshop.com/beginner/110_irsa/) lab, please complete the [Create an OIDC identity provider](https://www.eksworkshop.com/beginner/110_irsa/oidc-provider/) step now. You do not need to complete any other sections of that lab.
+{{% /notice %}}
+
+Create the service account for X-Ray.
 
 ```bash
-test -n "$ROLE_NAME" && echo ROLE_NAME is "$ROLE_NAME" || echo ROLE_NAME is not set
+eksctl create iamserviceaccount --name xray-daemon --namespace default --cluster eksworkshop-eksctl --attach-policy-arn arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess --approve --override-existing-serviceaccounts
 ```
 
-{{%expand "Expand here if you need to export the Role Name" %}}
-If `ROLE_NAME` is not set, please review: [/030_eksctl/test/](/030_eksctl/test/)
-{{% /expand %}}
+Apply a label to the service account
 
-```text
-# Example Output
-ROLE_NAME is eks-workshop-nodegroup
+```bash
+kubectl label serviceaccount xray-daemon app=xray-daemon
 ```
-
-```
-aws iam attach-role-policy --role-name $ROLE_NAME \
---policy-arn arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
-```
-
-

--- a/content/intermediate/245_x-ray/x-ray-daemon.md
+++ b/content/intermediate/245_x-ray/x-ray-daemon.md
@@ -5,7 +5,7 @@ weight: 11
 draft: false
 ---
 
-Now that we have modified the IAM role for the worker nodes to permit write operations to the X-Ray service, we are going to deploy the X-Ray [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) to the EKS cluster. The X-Ray daemon will be deployed to each worker node in the EKS cluster. For reference, see the [example implementation](https://github.com/aws-samples/eks-workshop/tree/main/content/intermediate/245_x-ray/daemonset.files) used in this module.
+Now that we have created a service account for X-Ray, we are going to deploy the X-Ray [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) to the EKS cluster. The X-Ray daemon will be deployed to each worker node in the EKS cluster. For reference, see the [example implementation](https://github.com/aws-samples/eks-workshop/tree/main/content/intermediate/245_x-ray/daemonset.files) used in this module.
 
 The [AWS X-Ray SDKs](https://docs.aws.amazon.com/xray/index.html#lang/en_us) are used to instrument your microservices. When using the DaemonSet in the [example implementation](https://github.com/aws-samples/eks-workshop/tree/main/content/intermediate/245_x-ray/daemonset.files), you need to configure it to point to **xray-service.default:2000**.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the X-Ray lab to use an IAM role with a service account for the X-Ray daemonset. Changed the docker image for the X-Ray daemon to include the AWS CLI so that it can use the role ARN to access X-Ray.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
