### PR TITLE
Enable cloudwatch cluster logging .

### DIFF
--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -47,9 +47,10 @@ managedNodeGroups:
 - name: nodegroup
   desiredCapacity: 3
 
-cloudWatch:
-  clusterLogging:
-    enableTypes: ["*"]
+# To enable all of the control plane logs, uncomment below:
+# cloudWatch:
+#  clusterLogging:
+#    enableTypes: ["*"]
 
 secretsEncryption:
   keyARN: ${MASTER_ARN}

--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -47,6 +47,10 @@ managedNodeGroups:
 - name: nodegroup
   desiredCapacity: 3
 
+cloudWatch:
+  clusterLogging:
+    enableTypes: ["*"]
+
 secretsEncryption:
   keyARN: ${MASTER_ARN}
 EOF


### PR DESCRIPTION
During the eks workshop I have seen Brent enabling the logging from the EKS dashboard. Thought it would be better to enable it from the ClusterConfig itself.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
