### PR TITLE
Iam group lab  fix cleanup

### DIFF
--- a/content/beginner/091_iam-groups/cleanup.md
+++ b/content/beginner/091_iam-groups/cleanup.md
@@ -43,5 +43,9 @@ aws iam delete-role --role-name k8sInteg
 
 rm /tmp/*.json
 rm /tmp/kubeconfig*
-rm -rf ~/.aws
+
+# reset aws credentials and config files
+rm  ~/.aws/{config,credentials}
+aws configure set default.region ${AWS_REGION}
+aws configure get default.region
 ```

--- a/content/beginner/091_iam-groups/cleanup.md
+++ b/content/beginner/091_iam-groups/cleanup.md
@@ -47,5 +47,4 @@ rm /tmp/kubeconfig*
 # reset aws credentials and config files
 rm  ~/.aws/{config,credentials}
 aws configure set default.region ${AWS_REGION}
-aws configure get default.region
 ```

--- a/content/beginner/091_iam-groups/configure-aws-auth.md
+++ b/content/beginner/091_iam-groups/configure-aws-auth.md
@@ -38,10 +38,7 @@ eksctl create iamidentitymapping \
   --username admin \
   --group system:masters
 ```
-eksctl create iamidentitymapping --cluster eksworkshop-eksctl --arn arn:aws:iam::${ACCOUNT_ID}:role/k8sDev --username dev-user
-eksctl create iamidentitymapping --cluster eksworkshop-eksctl --arn arn:aws:iam::${ACCOUNT_ID}:role/k8sInteg --username integ-user
-eksctl create iamidentitymapping --cluster eksworkshop-eksctl --arn arn:aws:iam::${ACCOUNT_ID}:role/k8sAdmin --username admin --group system:masters
-```
+
 It can also be used to delete entries
 
 `eksctl delete iamidentitymapping --cluster eksworkshop-eksctlv --arn arn:aws:iam::xxxxxxxxxx:role/k8sDev --username dev-user`

--- a/content/beginner/091_iam-groups/create_iam_users.md
+++ b/content/beginner/091_iam-groups/create_iam_users.md
@@ -7,21 +7,23 @@ weight: 22
 
 In order to test our scenarios, we will create 3 users, one for each groups we created :
 
-```
+```bash
 aws iam create-user --user-name PaulAdmin
 aws iam create-user --user-name JeanDev
 aws iam create-user --user-name PierreInteg
 ```
 
 Add users to associated groups:
-```
+
+```bash
 aws iam add-user-to-group --group-name k8sAdmin --user-name PaulAdmin
 aws iam add-user-to-group --group-name k8sDev --user-name JeanDev
 aws iam add-user-to-group --group-name k8sInteg --user-name PierreInteg
 ```
 
 Check users are correctly added in their groups:
-```
+
+```bash
 aws iam get-group --group-name k8sAdmin
 aws iam get-group --group-name k8sDev
 aws iam get-group --group-name k8sInteg

--- a/content/beginner/091_iam-groups/test-cluster-access.md
+++ b/content/beginner/091_iam-groups/test-cluster-access.md
@@ -91,8 +91,7 @@ aws sts get-caller-identity --profile admin
 
 It is also possible to specify the AWS_PROFILE to uses with the aws-iam-authenticator in the `.kube/config` file, so that it will uses the appropriate profile.
 
-
-### with dev profile 
+### with dev profile
 
 Create new KUBECONFIG file to test this:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* cleanup was deleting `~/.aws` folder and so default region config was also deleted. #866 
Now, the cleanup remove both files (not the folder) and reapply the initial setup of the `.aws` folder specified [here](https://www.eksworkshop.com/020_prerequisites/workspaceiam/)

* delete duplicate instruction.
* Minor fixes based on MD linter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
