### PR TITLE
updated config yaml to use AZ a,b,c specifically

### DIFF
--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -32,7 +32,7 @@ If you do see the correct role, proceed to next step to create an EKS cluster.
 ### Create an EKS cluster
 
 {{% notice warning %}}
-`eksclt` version must be 0.24.0 or above to deploy EKS 1.17, [click here](/030_eksctl/prerequisites) to get the latest version.
+`eksctl` version must be 0.24.0 or above to deploy EKS 1.17, [click here](/030_eksctl/prerequisites) to get the latest version.
 {{% /notice %}}
 
 Create an eksctl deployment file (eksworkshop.yaml) use in creating your cluster using the following syntax:
@@ -47,6 +47,8 @@ metadata:
   name: eksworkshop-eksctl
   region: ${AWS_REGION}
   version: "1.17"
+
+availabilityZones: ["${AWS_REGION}a", "${AWS_REGION}b", "${AWS_REGION}c"]
 
 managedNodeGroups:
 - name: nodegroup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I updated the cluster yaml config to always deploy nodes to AZ a, b, and c of the workshop's selected region.
As regions add more AZ's, AZ name dependencies in workshop modules (ex: Advanced VPC) may lead to the workshop module not being completed.
Also, a minor spelling update to one of the mentions of eksctl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
