### PR TITLE
Add reference to One Observability workshop

### DIFF
--- a/content/intermediate/250_cloudwatch_container_insights/_index.md
+++ b/content/intermediate/250_cloudwatch_container_insights/_index.md
@@ -18,4 +18,8 @@ In order to complete this lab you will need to have a working EKS Cluster, With 
 You will need to have completed the [Start the Workshop...](/020_prerequisites/) through  [Launching your cluster with Eksctl](/030_eksctl/) and [Install Helm CLI](/beginner/060_helm/helm_intro/install/) as well.
 {{% /notice %}}
 
+{{% notice tip%}}
+To learn all about our Observability features using Amazon CloudWatch and AWS X-Ray, take a look at our [One Observability Workshop](https://observability.workshop.aws)
+{{% /notice%}}
+
 ![alt text](/images/ekscwci/insights.png "CW Insights")

--- a/content/intermediate/250_cloudwatch_container_insights/wraup.md
+++ b/content/intermediate/250_cloudwatch_container_insights/wraup.md
@@ -49,3 +49,7 @@ aws iam detach-role-policy \
 ```
 
 ## Thank you for using CloudWatch Container Insights!
+
+{{% notice tip%}}
+There is a lot more to learn about our Observability features using Amazon CloudWatch and AWS X-Ray. Take a look at our [One Observability Workshop](https://observability.workshop.aws)
+{{% /notice%}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added references to our newly launched One Observability workshop. This will help users to know about the exhaustive set of AWS observability features using CloudWatch and X-Ray

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
