### PR TITLE
EKS Workshop Begineer 130 and 180 Lab Fix for ALB Ingress Controller …

### DIFF
--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -29,6 +29,12 @@ eksctl utils associate-iam-oidc-provider --cluster=eksworkshop-eksctl --approve
 Learn more about [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) in the Amazon EKS documentation.
 {{% /notice %}}
 
+Next, refer to the open source [AWS ALB Ingress controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) and scroll down to copy the current image version of the AWS ALB Ingress controller (Current `ALB_INGRESS_VERSION` is v1.1.8) and set the shell variable `ALB_INGRESS_VERSION` accordingly.
+
+```bash
+export ALB_INGRESS_VERSION=v1.1.8
+```
+
 Next, deploy the relevant RBAC roles and role bindings as required by the AWS ALB Ingress controller:
 
 ```bash

--- a/content/beginner/180_fargate/deploying-fargate.md
+++ b/content/beginner/180_fargate/deploying-fargate.md
@@ -7,7 +7,13 @@ draft: false
 
 #### Deploying Pods to Fargate
 
-Deploy the game [2048](https://play2048.co/) as a sample application to verify that the ALB Ingress Controller creates an Application Load Balancer as a result of the Ingress object.
+First, refer to the open source [AWS ALB Ingress controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) and scroll down to copy the current image version of the AWS ALB Ingress controller (Current `ALB_INGRESS_VERSION` is v1.1.8) and set the shell variable `ALB_INGRESS_VERSION` accordingly.
+
+```bash
+export ALB_INGRESS_VERSION=v1.1.8
+```
+
+Next, Deploy the game [2048](https://play2048.co/) as a sample application to verify that the ALB Ingress Controller creates an Application Load Balancer as a result of the Ingress object.
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/${ALB_INGRESS_VERSION}/docs/examples/2048/2048-namespace.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -635,10 +635,10 @@
 			"version": "github:dagrejs/dagre-d3#397c2a9e1592b3ea464bbd50d209afb4562cc98c",
 			"from": "github:dagrejs/dagre-d3",
 			"requires": {
-				"d3": "^5.14",
-				"dagre": "^0.8.5",
-				"graphlib": "^2.1.8",
-				"lodash": "^4.17.15"
+				"d3": "5.16",
+				"dagre": "0.8.5",
+				"graphlib": "2.1.8",
+				"lodash": "4.17.19"
 			},
 			"dependencies": {
 				"dagre": {


### PR DESCRIPTION
…Version

*Issue #, if available:*  ALB Ingress Controller Version isnt set for 130 and 180 Labs which makes the Labs steps to fail.

*Description of changes:*

Added the following changes to both the labs to get this issue fixed and have the labs sequential steps working :
First, refer to the open source [AWS ALB Ingress controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) and scroll down to copy the current image version of the AWS ALB Ingress controller (Current `ALB_INGRESS_VERSION` is v1.1.8) and set the shell variable `ALB_INGRESS_VERSION` accordingly.

```bash
export ALB_INGRESS_VERSION=v1.1.8
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
