### PR TITLE
updating custom image on Kubeflow Fairing chapter

### DIFF
--- a/content/advanced/420_kubeflow/fairing.md
+++ b/content/advanced/420_kubeflow/fairing.md
@@ -19,7 +19,7 @@ aws iam attach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:
 ```
 
 #### Create Jupyter notebook server
-Create new notebook server by following [Jupyter notebook chapter] (/advanced/420_kubeflow/jupyter). Before you jump to the link, take a note of custom image (**seedjeffwan/tensorflow-1.13.1-notebook-cpu:awscli-v2**) that you will use for **eks-kubeflow-workshop** notebook server. Below screenshot depicts how to use custom image
+Create new notebook server by following [Jupyter notebook chapter] (/advanced/420_kubeflow/jupyter). Before you jump to the link, take a note of custom image (**527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0**) that you will use for **eks-kubeflow-workshop** notebook server. Below screenshot depicts how to use custom image
 
 ![dashboard](/images/kubeflow/eks-kubeflow-workshop-notebook-server.png)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update custom image to "527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0". This brings Kubeflow 1.1 features that will be merged shortly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
