### PR TITLE
Added deletion step for nginx Service

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/cleanup.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/cleanup.md
@@ -7,6 +7,7 @@ Let's cleanup this tutorial
 
 ```
 kubectl delete deployments --all
+kubectl delete service  nginx
 ```
 Edit aws-node configmap and comment AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG and its value
 ```


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

At the beginning of [Test Networking](https://www.eksworkshop.com/beginner/160_advanced-networking/secondary_cidr/test_networking/) the instructions to exceute `kubectl expose deployment/nginx --type=NodePort --port 80` created a Kubernetes Service. This Service is not being cleaned up

```bash
steven:~/environment $ k get all
NAME                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)        AGE
service/kubernetes   ClusterIP   10.100.0.1     <none>        443/TCP        5d4h
service/nginx        NodePort    10.100.21.38   <none>        80:31890/TCP   9m17s
```

Added a deletion command to remove the object. 

Thanks!