### PR TITLE
remove duplicate bullet points in OPA guide

### DIFF
--- a/content/intermediate/310_open_policy_agent/intro.md
+++ b/content/intermediate/310_open_policy_agent/intro.md
@@ -18,10 +18,6 @@ OPA generates policy decisions by evaluating the query input and against policie
 - Which registries binaries can be downloaded from.
 - Which OS capabilities a container can execute with.
 - Which times of day the system can be accessed at.
-- Which subnets egress traffic is allowed to.
-- Which clusters a workload must be deployed to.
-- Which registries binaries can be downloaded from.
-- Which OS capabilities a container can execute with.
-- Which times of day the system can be accessed at.
+
 
 Policy decisions are not limited to simple yes/no or allow/deny answers. Like query inputs, your policies can generate arbitrary structured data as output.


### PR DESCRIPTION
remove duplicate bullet points

*Issue #, if available:*
N/A but will happily make a ticket if necessary

*Description of changes:*
 I removed duplicate entries of:
- Which subnets egress traffic is allowed to.
- Which clusters a workload must be deployed to.
- Which registries binaries can be downloaded from.
- Which OS capabilities a container can execute with.
- Which times of day the system can be accessed at.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
