### PR TITLE
get-login-password is deprecated using get-login

### DIFF
--- a/content/intermediate/310_open_policy_agent/policy-example-1.md
+++ b/content/intermediate/310_open_policy_agent/policy-example-1.md
@@ -92,7 +92,11 @@ docker pull nginx
 Retag `latest` with our repository name and push the image to your own Amazon ECR. We start by logging into Amazon ECR.
 
 ```
-aws ecr get-login —no-include-email | bash -
+aws ecr get-login-password \
+    --region <region> \
+| docker login \
+    --username AWS \
+    --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
 ```
 
 Enlist the local docker images to capture the image ID


### PR DESCRIPTION
`aws ecr get-login` IS DEPRECATED using `get-login-password` instead

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
