### PR TITLE
Update test-cluster-access.md

### DIFF
--- a/content/beginner/091_iam-groups/test-cluster-access.md
+++ b/content/beginner/091_iam-groups/test-cluster-access.md
@@ -33,10 +33,10 @@ source_profile=eksInteg
 EoF
 ```
 
-#### Create `~/.aws/credentials`:
+#### Add in `~/.aws/credentials`:
 
 ```bash
-cat << EoF > ~/.aws/credentials
+cat << EoF >> ~/.aws/credentials
 
 [eksAdmin]
 aws_access_key_id=$(jq -r .AccessKey.AccessKeyId /tmp/PaulAdmin.json)


### PR DESCRIPTION
Add in ~/.aws/credentials instead of Create ~/.aws/credentials which overwrites existing credentials file so users lose their stored credentials.

*Issue #, if available:*
Create ~/.aws/credentials cause users to lose stored credentials

*Description of changes:*
Instead of overwriting the credentials file, add new credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
