### PR TITLE
There is not file name as efs-pv.yaml

### DIFF
--- a/content/beginner/190_efs/efs-csi-driver.md
+++ b/content/beginner/190_efs/efs-csi-driver.md
@@ -36,17 +36,17 @@ Next we will deploy a persistent volume using the EFS created.
 ```
 mkdir ~/environment/efs
 cd ~/environment/efs
-wget https://eksworkshop.com/beginner/190_efs/efs.files/efs-pv.yaml
+wget https://eksworkshop.com/beginner/190_efs/efs.files/efs-pvc.yaml
 ```
 
 We need to update this manifest with the EFS ID created:
 ```
-sed -i "s/EFS_VOLUME_ID/$FILE_SYSTEM_ID/g" efs-pv.yaml
+sed -i "s/EFS_VOLUME_ID/$FILE_SYSTEM_ID/g" efs-pvc.yaml
 ```
 
 And then apply:
 ```
-kubectl apply -f efs-pv.yaml
+kubectl apply -f efs-pvc.yaml
 ```
 
 Next, check if a PVC resource was created. The output from the command should look similar to what is shown below, with the **STATUS** field set to **Bound**.


### PR DESCRIPTION
There is not file name as efs-pv.yaml.
But we have file as efs-pvc.yaml, which points to real file - https://github.com/aws-samples/eks-workshop/blob/main/content/beginner/190_efs/efs.files/efs-pvc.yaml
Which have the code for pv, pvc, sc.

```
$ cat efs-pvc.yaml
---
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: efs-sc
provisioner: efs.csi.aws.com

---
apiVersion: v1
kind: PersistentVolume
metadata:
  name: efs-pvc
spec:
  capacity:
    storage: 5Gi
  volumeMode: Filesystem
  accessModes:
    - ReadWriteMany
  persistentVolumeReclaimPolicy: Retain
  storageClassName: efs-sc
  csi:
    driver: efs.csi.aws.com
    volumeHandle: fs-a29f8be3

---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: efs-storage-claim
  namespace: storage
spec:
  accessModes:
    - ReadWriteMany
  storageClassName: efs-sc
  resources:
    requests:
      storage: 5Gi
```

*Issue #, if available:*

*Description of changes:*
From the page [EFS Provisioner for EKS with CSI Driver ](https://www.eksworkshop.com/beginner/190_efs/launching-efs/), which mention few commands for a file named as `efs-pv.yaml` but it should be `efs-pvc.yaml`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
