### PR TITLE
Link is not correct

### DIFF
--- a/content/beginner/190_efs/efs-csi-driver.md
+++ b/content/beginner/190_efs/efs-csi-driver.md
@@ -6,7 +6,7 @@ draft: false
 ---
 
 ## About the Amazon EFS CSI Driver
-On Amazon EKS, the open-source [EFS Container Storage Interface (CSI)](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) driver is used to manage the attachment of Amazon EFS volumes to Kubernetes Pods.
+On Amazon EKS, the open-source [EFS Container Storage Interface (CSI)](https://github.com/kubernetes-sigs/aws-efs-csi-driver) driver is used to manage the attachment of Amazon EFS volumes to Kubernetes Pods.
 
 ## Deploy EFS CSI Driver
 We are going to deploy the driver using Helm packages:


### PR DESCRIPTION
EFS Container Storage Interface (CSI) points to EBS drive i.e. https://github.com/kubernetes-sigs/aws-ebs-csi-driver
With this PR, I have correct the link, which should point to https://github.com/kubernetes-sigs/aws-efs-csi-driver

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
