### PR TITLE
Cleanup was missing the appmesh-controller service account

### DIFF
--- a/content/advanced/320_servicemesh_with_appmesh/cleanup/_index.md
+++ b/content/advanced/320_servicemesh_with_appmesh/cleanup/_index.md
@@ -36,3 +36,8 @@ done
 ```bash
 kubectl delete namespace appmesh-system
 ```
+
+## Delete the appmesh-controller service account
+```bash
+eksctl delete iamserviceaccount --cluster eksworkshop-eksctl   --namespace appmesh-system --name appmesh-controller
+```


### PR DESCRIPTION
*Issue #, if available:*

An error occurred if you've created the mesh, deleted everything, and tried to recreate the mesh again, it is necessary to delete the appmesh-controller service account

*Description of changes:*

Deletion of appmesh-controller service account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
