### PR TITLE
Tag addition to ASG to auto discover node group by the cluster autoscaler.

### DIFF
--- a/content/beginner/080_scaling/deploy_ca.md
+++ b/content/beginner/080_scaling/deploy_ca.md
@@ -132,6 +132,15 @@ Tokens:              cluster-autoscaler-token-vfk8n
 Events:              <none>
 {{< /output >}}
 
+And
+Make sure you have added correct tags to your asg to discover the nodegroup (--node-group-auto-discovery=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/eksworkshop-eksctl line in cluster-autoscaler-autodiscover.yaml)
+
+```bash
+aws autoscaling create-or-update-tags \
+  --tags ResourceId=${ASG_NAME},ResourceType=auto-scaling-group,Key="k8s.io/cluster-autoscaler/eksworkshop-eksctl",PropagateAtLaunch=true \
+  ResourceId=${ASG_NAME},ResourceType=auto-scaling-group,Key="k8s.io/cluster-autoscaler/enabled",PropagateAtLaunch=true
+```
+
 ## Deploy the Cluster Autoscaler (CA)
 
 Deploy the Cluster Autoscaler to your cluster with the following command.


### PR DESCRIPTION
--node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/jwr-eks-poc
Without the ASG tag its throwing error 
I1006 06:25:08.201997       1 utils.go:574] Skipping ip-xxx-xxx-xxx-xxx.ap-south-1.compute.internal - no node group config

After adding the tags it discovered the Node group and started scaling.
I1006 06:25:38.419280       1 waste.go:57] Expanding Node Group eksctl-jwr-eks-poc-nodegroup-ng-1-NodeGroup-1HXPDP6O2CEHV would waste 50.00% CPU, 47.62% Memory, 48.81% Blended
Ref: https://aws.amazon.com/premiumsupport/knowledge-center/eks-cluster-autoscaler-setup/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
