### PR TITLE
Update efs-csi-driver.md

### DIFF
--- a/content/beginner/190_efs/efs-csi-driver.md
+++ b/content/beginner/190_efs/efs-csi-driver.md
@@ -48,6 +48,10 @@ And then apply:
 ```
 kubectl apply -f efs-pvc.yaml
 ```
+*If you get an error on the efs-pvc.yaml apply you may have to manually create the storage namespace.
+```
+kubectl create namespace storage
+```
 
 Next, check if a PVC resource was created. The output from the command should look similar to what is shown below, with the **STATUS** field set to **Bound**.
 ```


### PR DESCRIPTION
When doing the lab for the efs provisioner the page doesn't match up with the youtube video.  Following the directions I got an error because the storage namespace didnt exist.  I created the namespace manually and the rest of the lab was fine.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
