### PR TITLE
Added environment variable for Rego Policy

### DIFF
--- a/content/intermediate/310_open_policy_agent/policy-example-1.md
+++ b/content/intermediate/310_open_policy_agent/policy-example-1.md
@@ -51,7 +51,7 @@ package kubernetes.admission
 deny[msg] {                                                                
   input.request.kind.kind == "Pod"                                        
   image := input.request.object.spec.containers[_].image                 
-  not startswith(image, "${ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com") 
+  not startswith(image, "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com") 
   msg := sprintf("image '%v' comes from untrusted registry", [image])  
 }
 EOF


### PR DESCRIPTION
Rego policy was hard coded for us-west-2. Added AWS_REGION to the rego policy to make it work on different regions.

*Issue #, if available:*

*Description of changes:*

Added environment variable to the rego policy generation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
