### PR TITLE
Update default branch name

### DIFF
--- a/content/intermediate/260_weave_flux/codepipeline.md
+++ b/content/intermediate/260_weave_flux/codepipeline.md
@@ -20,7 +20,7 @@ Click the **Launch** button to create the CloudFormation stack in the AWS Manage
 | ------ |:------:|:--------:|
 | CodePipeline & EKS |  {{< cf-launch "weave_flux_pipeline.cfn.yml" "image-codepipeline" >}} | {{< cf-download "weave_flux_pipeline.cfn.yml" >}}  |
 
-After the console is open, enter your GitHub username, personal access token (created in previous step) and then click the "Create stack" button located at the bottom of the page.
+After the console is open, enter your GitHub username, personal access token (created in previous step), configure the branch to main instead of master, and then click the "Create stack" button located at the bottom of the page.
 
 ![CloudFormation Stack](/images/weave_flux/cloudformation_stack.png)
 


### PR DESCRIPTION
Since the recent change on the default branch name on Github, CodePipeline is failing as master doesn't exist.

https://github.com/github/renaming

This is just a temporary fix, best course of action will be to update the Cloudformation template.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
