### PR TITLE
Changed default branch name to main

### DIFF
--- a/templates/weave_flux_pipeline.cfn.yml
+++ b/templates/weave_flux_pipeline.cfn.yml
@@ -15,7 +15,7 @@ Parameters:
 
   GitBranch:
     Type: String
-    Default: master
+    Default: main
     Description: GitHub git repository branch - change triggers a new build
     MinLength: 1
     MaxLength: 100


### PR DESCRIPTION
Update of the default branch name for Github repo.

*Issue #, if available:*

*Description of changes:*
Updated default value for branch name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
