### PR TITLE
Added default branch name to Flux

### DIFF
--- a/content/intermediate/260_weave_flux/installweaveflux.md
+++ b/content/intermediate/260_weave_flux/installweaveflux.md
@@ -55,6 +55,7 @@ helm upgrade -i flux fluxcd/flux \
 helm upgrade -i helm-operator fluxcd/helm-operator \
 --set helm.versions=v3 \
 --set git.ssh.secretName=flux-git-deploy \
+--set git.branch=main \
 --namespace flux
 ```
 


### PR DESCRIPTION
Set default branch name to main according to the new Github default branch name.

Reference: https://github.com/fluxcd/flux/tree/master/chart/flux#configuration

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
