### PR TITLE
Replaced driver installation method

### DIFF
--- a/content/beginner/190_efs/efs-csi-driver.md
+++ b/content/beginner/190_efs/efs-csi-driver.md
@@ -9,10 +9,9 @@ draft: false
 On Amazon EKS, the open-source [EFS Container Storage Interface (CSI)](https://github.com/kubernetes-sigs/aws-efs-csi-driver) driver is used to manage the attachment of Amazon EFS volumes to Kubernetes Pods.
 
 ## Deploy EFS CSI Driver
-We are going to deploy the driver using Helm packages:
+We are going to deploy the driver using the stable release:
 ```
-helm repo add aws-efs-csi-driver https://kubernetes-sigs.github.io/aws-efs-csi-driver/
-helm install aws-efs-csi-driver aws-efs-csi-driver/aws-efs-csi-driver
+kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.0"
 ```
 
 Verify pods have been deployed:


### PR DESCRIPTION
At least in my case (EKS 1.17+) helm is not able to create the release correctly. Also, it is a dependency that adds a bit of noise to this (great) laboratory. So the PR is just applying the manifest for the stable version of the driver.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
