### PR TITLE
Update location of helm stable repo to https://charts.helm.sh/stable

### DIFF
--- a/content/beginner/060_helm/helm_intro/install.md
+++ b/content/beginner/060_helm/helm_intro/install.md
@@ -25,7 +25,7 @@ Homebrew on macOS.
 Download the `stable` repository so we have something to start with:
 
 ```sh
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 ```
 
 Once this is installed, we will be able to list the charts you can install:

--- a/content/beginner/060_helm/helm_nginx/updatecharts.md
+++ b/content/beginner/060_helm/helm_nginx/updatecharts.md
@@ -25,7 +25,7 @@ To update Helm's local list of Charts, run:
 
 ```
 # first, add the default repository, then update
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Old repo location https://kubernetes-charts.storage.googleapis.com/ is broken.
Updated to newer https://charts.helm.sh/stable in two .md files in the 060_helm workshop module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
