### PR TITLE
Update efs-pvc.yaml

### DIFF
--- a/content/beginner/190_efs/efs.files/efs-pvc.yaml
+++ b/content/beginner/190_efs/efs.files/efs-pvc.yaml
@@ -1,4 +1,9 @@
----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: storage
+  
+------
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added creation of namespace "storage". This was previously included in efs-provisioner-deployment.yaml which is no longer used.

Without creation of this namespace, the remaining lab .yaml manifest files all fail, because they assume the namespace "storage" exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
