### PR TITLE
Update: remove rbac-user from ConfigMap

### DIFF
--- a/content/beginner/090_rbac/cleanup.md
+++ b/content/beginner/090_rbac/cleanup.md
@@ -11,11 +11,24 @@ Once you have completed this chapter, you can cleanup the files and resources yo
 unset AWS_SECRET_ACCESS_KEY
 unset AWS_ACCESS_KEY_ID
 kubectl delete namespace rbac-test
-rm aws-auth.yaml
 rm rbacuser_creds.sh
 rm rbacuser-role.yaml
 rm rbacuser-role-binding.yaml
 aws iam delete-access-key --user-name=rbac-user --access-key-id=$(jq -r .AccessKey.AccessKeyId /tmp/create_output.json)
 aws iam delete-user --user-name rbac-user
 rm /tmp/create_output.json
+```
+
+Next remove the rbac-user mapping from the existing configMap by editing the existing aws-auth.yaml file:
+
+```
+data:
+  mapUsers: |
+    []
+```
+
+And apply the ConfigMap and delete the aws-auth.yaml file
+```bash
+kubectl apply -f aws-auth.yaml
+rm aws-auth.yaml
 ```


### PR DESCRIPTION
Remove rbac-user from ConfigMap before deleting the aws-auth.yaml file

*Issue #, if available:*
Forget to remove rbac-user 
*Description of changes:*
Remove rbac-user from ConfigMap before deleting the aws-auth.yaml file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
