### PR TITLE
Add "--set git.branch=main" while installing flux

### DIFF
--- a/content/intermediate/260_weave_flux/installweaveflux.md
+++ b/content/intermediate/260_weave_flux/installweaveflux.md
@@ -50,6 +50,7 @@ helm repo add fluxcd https://charts.fluxcd.io
 
 helm upgrade -i flux fluxcd/flux \
 --set git.url=git@github.com:${YOURUSER}/k8s-config \
+--set git.branch=main
 --namespace flux
 
 helm upgrade -i helm-operator fluxcd/helm-operator \


### PR DESCRIPTION
Since the prior "master" branch of GitHub is renamed to "main", the helm upgrade -i flux fluxcd/flux command should include this flag to explicitly tells flux to point to the "main" branch of the Git repo; otherwise it still takes "master" as the default.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
