### PR TITLE
New module for FSx Lustre setup and PVC test

### DIFF
--- a/content/beginner/190_fsx_lustre/_index.md
+++ b/content/beginner/190_fsx_lustre/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Deploying Stateful Microservices with Amazon FSx Lustre"
+chapter: true
+weight: 190
+pre: '<i class="fa fa-film" aria-hidden="true"></i> '
+tags:
+  - beginner
+  - CON206
+---
+
+# Deploying Stateful Microservices with Amazon FSx Lustre
+
+{{< youtube ttCAqwnN_Qo >}}
+
+Amazon FSx for Lustre is a fully managed service that provides cost-effective, high-performance storage for compute workloads. Many workloads such as machine learning, high performance computing (HPC), video rendering, and financial simulations depend on compute instances accessing the same set of data through high-performance shared storage.
+
+Powered by Lustre, the world's most popular high-performance file system, FSx for Lustre offers sub-millisecond latencies, up to hundreds of gigabytes per second of throughput, and millions of IOPS. It provides multiple deployment options and storage types to optimize cost and performance for your workload requirements.
+
+FSx for Lustre file systems can also be linked to Amazon S3 buckets, allowing you to access and process data concurrently from both a high-performance file system and from the S3 API.

--- a/content/beginner/190_fsx_lustre/cleaning.md
+++ b/content/beginner/190_fsx_lustre/cleaning.md
@@ -21,8 +21,8 @@ eksctl delete iamserviceaccount \
     --region $AWS_REGION \
     --name fsx-csi-controller-sa \
     --namespace kube-system \
-    --cluster $CLUSTER_NAME \
+    --cluster $CLUSTER_NAME
 
 aws iam delete-policy \
-    --policy-name arn:aws:iam::$ACCOUNT_ID:policy/Amazon_FSx_Lustre_CSI_Driver
+    --policy-arn arn:aws:iam::$ACCOUNT_ID:policy/Amazon_FSx_Lustre_CSI_Driver
 ```

--- a/content/beginner/190_fsx_lustre/cleaning.md
+++ b/content/beginner/190_fsx_lustre/cleaning.md
@@ -5,3 +5,24 @@ weight: 15
 draft: false
 ---
 ### Cleaning up
+
+Once we are done, let's cleanup the resources specific to this module:
+
+```
+kubectl delete -f "https://raw.githubusercontent.com/kubernetes-sigs/aws-fsx-csi-driver/master/examples/kubernetes/dynamic_provisioning_s3/specs/pod.yaml"
+kubectl delete -f claim.yaml
+kubectl delete -f storageclass.yaml
+kubectl delete -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+
+aws s3 rm --recursive s3://$S3_LOGS_BUCKET
+aws s3 rb  s3://$S3_LOGS_BUCKET
+
+eksctl delete iamserviceaccount \
+    --region $AWS_REGION \
+    --name fsx-csi-controller-sa \
+    --namespace kube-system \
+    --cluster $CLUSTER_NAME \
+
+aws iam delete-policy \
+    --policy-name arn:aws:iam::$ACCOUNT_ID:policy/Amazon_FSx_Lustre_CSI_Driver
+```

--- a/content/beginner/190_fsx_lustre/cleaning.md
+++ b/content/beginner/190_fsx_lustre/cleaning.md
@@ -1,0 +1,7 @@
+---
+title: "Clean Up"
+date: 2019-04-09T00:00:00-03:00
+weight: 15
+draft: false
+---
+### Cleaning up

--- a/content/beginner/190_fsx_lustre/deploying-services.md
+++ b/content/beginner/190_fsx_lustre/deploying-services.md
@@ -1,0 +1,135 @@
+---
+title: "Deploying the Stateful Services"
+date: 2019-04-09T00:00:00-03:00
+weight: 14
+draft: false
+---
+
+#### Deploy a Kubernetes storage class, persistent volume claim, and sample application to verify that the CSI driver is working
+
+This procedure uses the Dynamic volume provisioning for Amazon S3 from the Amazon FSx for Lustre Container Storage Interface (CSI) driver GitHub repository to consume a dynamically-provisioned Amazon FSx for Lustre volume.
+
+1. Create an Amazon S3 bucket and a folder within it named export by creating and copying a file to the bucket.
+    ```
+    aws s3 mb s3://<fsx-csi>
+    echo test-file >> testfile
+    aws s3 cp testfile s3://<fsx-csi>/export/testfile
+    ```
+
+
+2. Create the storageclass definition that should interpolate variables from your shell variables that we defined in on the previous page.
+    ```
+    cat << EOF > storageclass.yaml
+    ---
+    parameters:
+    subnetId: ${SUBNET_ID}
+    securityGroupIds: ${SECURITY_GROUP_ID}
+    s3ImportPath: s3://${S3_LOGS_BUCKET}
+    s3ExportPath: s3://${S3_LOGS_BUCKET}/export
+    deploymentType: <SCRATCH_2>
+    ```
+    - **subnetId** – The subnet ID that the Amazon FSx for Lustre file system should be created in. Amazon FSx for Lustre is not supported in all Availability Zones. Open the Amazon FSx for Lustre console at https://console.aws.amazon.com/fsx/ to confirm that the subnet that you want to use is in a supported Availability Zone. The subnet can include your nodes, or can be a different subnet or VPC. If the subnet that you specify is not the same subnet that you have nodes in, then your VPCs must be connected, and you must ensure that you have the necessary ports open in your security groups.
+
+    - **securityGroupIds** – The security group ID for your nodes.
+
+    - **s3ImportPath** – The Amazon Simple Storage Service data repository that you want to copy data from to the persistent volume. Specify the fsx-csi bucket that you created in step 1.
+
+    - **s3ExportPath** – The Amazon S3 data repository that you want to export new or modified files to. Specify the fsx-csi/export folder that you created in step 1.
+
+    - **deploymentType** – The file system deployment type. Valid values are SCRATCH_1, SCRATCH_2, and PERSISTENT_1. For more information about deployment types, see Create your Amazon FSx for Lustre file system.
+
+        **Note**
+
+        The Amazon S3 bucket for s3ImportPath and s3ExportPath must be the same, otherwise the driver cannot create the Amazon FSx for Lustre file system. The s3ImportPath can stand alone. A random path will be created automatically like s3://ml-training-data-000/FSxLustre20190308T012310Z. The s3ExportPath cannot be used without specifying a value for S3ImportPath.
+
+3. Create the storageclass.
+    ```
+    kubectl apply -f storageclass.yaml
+    ```
+4. Download the persistent volume claim manifest.
+    ```
+    curl -o claim.yaml https://raw.githubusercontent.com/kubernetes-sigs/aws-fsx-csi-driver/master/examples/kubernetes/dynamic_provisioning_s3/specs/claim.yaml
+    ```
+    **(Optional)** Edit the claim.yaml file. Change the following <value> to one of the increment values listed below, based on your storage requirements and the deploymentType that you selected in a previous step.
+
+    ```
+    storage: <1200Gi>
+    ```
+
+        - SCRATCH_2 and PERSISTENT – 1.2 TiB, 2.4 TiB, or increments of 2.4 TiB over 2.4 TiB.
+
+        - SCRATCH_1 – 1.2 TiB, 2.4 TiB, 3.6 TiB, or increments of 3.6 TiB over 3.6 TiB.
+
+5. Create the persistent volume claim.
+
+    ```
+    kubectl apply -f claim.yaml
+    ```
+
+6. Confirm that the file system is provisioned.
+    ```
+    kubectl get pvc
+    ```
+
+    **Output:**
+
+    ```
+    NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+    fsx-claim   Bound    pvc-15dad3c1-2365-11ea-a836-02468c18769e   1200Gi     RWX            fsx-sc         7m37s
+    ```
+
+    *The STATUS may show as Pending for 5-10 minutes, before changing to Bound. Don't continue with the next step until the STATUS is Bound.*
+
+7. Deploy the sample application.
+
+    ```
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-fsx-csi-driver/master/examples/kubernetes/dynamic_provisioning_s3/specs/pod.yaml
+    ```
+
+8. Verify that the sample application is running.
+
+    ```
+        kubectl get pods
+    ```
+        **Output:**
+    ```
+        NAME      READY   STATUS              RESTARTS   AGE
+        fsx-app   1/1     Running             0          8s
+    ```
+
+#### Access Amazon S3 files from the Amazon FSx for Lustre file system
+
+1. If you only want to import data and read it without any modification and creation, then you don't need a value for s3ExportPath in your storageclass.yaml file. Verify that data was written to the Amazon FSx for Lustre file system by the sample app.
+
+    ```
+    kubectl exec -it fsx-app ls /data
+    ```
+    **Output:***
+    ```
+    export  out.txt
+    ```
+The sample app wrote the out.txt file to the file system.
+
+2. Archive files to the s3ExportPath. For new files and modified files, you can use the Lustre user space tool to archive the data back to Amazon S3 using the value that you specified for s3ExportPath.
+
+    Export the file back to Amazon S3.
+
+    ```
+    kubectl exec -ti fsx-app -- lfs hsm_archive /data/out.txt
+    ```
+
+    New files aren't synced back to Amazon S3 automatically. In order to sync files to the s3ExportPath, you need to install the Lustre client in your container image and manually run the lfs hsm_archive command. The container should run in privileged mode with the CAP_SYS_ADMIN capability.
+    This example uses a lifecycle hook to install the Lustre client for demonstration purpose. A normal approach is building a container image with the Lustre client.
+
+3. Confirm that the out.txt file was written to the s3ExportPath folder in Amazon S3.
+
+    ```
+    aws s3 ls fsx-csi/export/
+    ```
+
+    **Output:**
+
+    ```
+    2019-12-23 12:11:35       4553 out.txt
+    2019-12-23 11:41:21         10 testfile
+    ```

--- a/content/beginner/190_fsx_lustre/deploying-services.md
+++ b/content/beginner/190_fsx_lustre/deploying-services.md
@@ -11,9 +11,9 @@ This procedure uses the Dynamic volume provisioning for Amazon S3 from the Amazo
 
 1. Create an Amazon S3 bucket and a folder within it named export by creating and copying a file to the bucket.
     ```
-    aws s3 mb s3://<fsx-csi>
+    aws s3 mb s3://$S3_LOGS_BUCKET
     echo test-file >> testfile
-    aws s3 cp testfile s3://<fsx-csi>/export/testfile
+    aws s3 cp testfile s3://$S3_LOGS_BUCKET/export/testfile
     ```
 
 

--- a/content/beginner/190_fsx_lustre/deploying-services.md
+++ b/content/beginner/190_fsx_lustre/deploying-services.md
@@ -21,20 +21,31 @@ This procedure uses the Dynamic volume provisioning for Amazon S3 from the Amazo
     ```
     cat << EOF > storageclass.yaml
     ---
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+        name: fsx-sc
+    provisioner: fsx.csi.aws.com
     parameters:
-    subnetId: ${SUBNET_ID}
-    securityGroupIds: ${SECURITY_GROUP_ID}
-    s3ImportPath: s3://${S3_LOGS_BUCKET}
-    s3ExportPath: s3://${S3_LOGS_BUCKET}/export
-    deploymentType: <SCRATCH_2>
+        subnetId: ${SUBNET_ID}
+        securityGroupIds: ${SECURITY_GROUP_ID}
+        s3ImportPath: s3://${S3_LOGS_BUCKET}
+        s3ExportPath: s3://${S3_LOGS_BUCKET}/export
+        deploymentType: SCRATCH_2
+    mountOptions:
+        - flock
+    EOF
     ```
+
+    Explanation of the settings:
+
     - **subnetId** – The subnet ID that the Amazon FSx for Lustre file system should be created in. Amazon FSx for Lustre is not supported in all Availability Zones. Open the Amazon FSx for Lustre console at https://console.aws.amazon.com/fsx/ to confirm that the subnet that you want to use is in a supported Availability Zone. The subnet can include your nodes, or can be a different subnet or VPC. If the subnet that you specify is not the same subnet that you have nodes in, then your VPCs must be connected, and you must ensure that you have the necessary ports open in your security groups.
 
     - **securityGroupIds** – The security group ID for your nodes.
 
-    - **s3ImportPath** – The Amazon Simple Storage Service data repository that you want to copy data from to the persistent volume. Specify the fsx-csi bucket that you created in step 1.
+    - **s3ImportPath** – The Amazon Simple Storage Service data repository that you want to copy data from to the persistent volume.
 
-    - **s3ExportPath** – The Amazon S3 data repository that you want to export new or modified files to. Specify the fsx-csi/export folder that you created in step 1.
+    - **s3ExportPath** – The Amazon S3 data repository that you want to export new or modified files to. 
 
     - **deploymentType** – The file system deployment type. Valid values are SCRATCH_1, SCRATCH_2, and PERSISTENT_1. For more information about deployment types, see Create your Amazon FSx for Lustre file system.
 
@@ -104,11 +115,14 @@ This procedure uses the Dynamic volume provisioning for Amazon S3 from the Amazo
     ```
     kubectl exec -it fsx-app ls /data
     ```
-    **Output:***
+
+    **Output:**
+    
+    The sample app wrote the out.txt file to the file system.
+
     ```
     export  out.txt
     ```
-The sample app wrote the out.txt file to the file system.
 
 2. Archive files to the s3ExportPath. For new files and modified files, you can use the Lustre user space tool to archive the data back to Amazon S3 using the value that you specified for s3ExportPath.
 

--- a/content/beginner/190_fsx_lustre/deploying-services.md
+++ b/content/beginner/190_fsx_lustre/deploying-services.md
@@ -138,7 +138,7 @@ This procedure uses the Dynamic volume provisioning for Amazon S3 from the Amazo
 3. Confirm that the out.txt file was written to the s3ExportPath folder in Amazon S3.
 
     ```
-    aws s3 ls fsx-csi/export/
+    aws s3 ls s3://$S3_LOGS_BUCKET/export/
     ```
 
     **Output:**

--- a/content/beginner/190_fsx_lustre/launching-fsx.md
+++ b/content/beginner/190_fsx_lustre/launching-fsx.md
@@ -13,7 +13,6 @@ For detailed descriptions of the available parameters and complete examples that
 #### Prerequisites
 
 ```
-REGION=us-west-2
 CLUSTER_NAME=eksworkshop-eksctl
 VPC_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query "cluster.resourcesVpcConfig.vpcId" --output text)
 SUBNET_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query "cluster.resourcesVpcConfig.subnetIds[0]" --output text)
@@ -38,8 +37,8 @@ You must have:
 1. Create an AWS Identity and Access Management OIDC provider and associate it with your cluster.
     ```
     eksctl utils associate-iam-oidc-provider \
-        --region <region-code> \
-        --cluster <prod> \
+        --region $AWS_REGION \
+        --cluster $CLUSTER_NAME \
         --approve
     ```
 
@@ -93,7 +92,7 @@ You must have:
 2. Create the policy.
 ```
     aws iam create-policy \
-        --policy-name <Amazon_FSx_Lustre_CSI_Driver> \
+        --policy-name Amazon_FSx_Lustre_CSI_Driver \
         --policy-document file://fsx-csi-driver.json
 ```
     *Take note of the policy Amazon Resource Name (ARN) that is returned.*
@@ -101,10 +100,10 @@ You must have:
 3. Create a Kubernetes service account for the driver and attach the policy to the service account. Replacing the ARN of the policy with the ARN returned in the previous step.
     ```
     eksctl create iamserviceaccount \
-        --region <region-code> \
+        --region $AWS_REGION \
         --name fsx-csi-controller-sa \
         --namespace kube-system \
-        --cluster <prod> \
+        --cluster $CLUSTER_NAME \
         --attach-policy-arn arn:aws:iam::<111122223333:policy/Amazon_FSx_Lustre_CSI_Driver> \
         --approve
     ```

--- a/content/beginner/190_fsx_lustre/launching-fsx.md
+++ b/content/beginner/190_fsx_lustre/launching-fsx.md
@@ -1,0 +1,155 @@
+---
+title: "Creating an Fsx Lustre File System"
+date: 2020-11-03T00:00:00-03:00
+weight: 10
+draft: false
+---
+
+The Amazon FSx for Lustre Container Storage Interface (CSI) driver provides a CSI interface that allows Amazon EKS clusters to manage the lifecycle of Amazon FSx for Lustre file systems.
+For detailed descriptions of the available parameters and complete examples that demonstrate the driver's features, see the Amazon FSx for Lustre Container Storage Interface (CSI) driver project on GitHub.  
+
+
+
+#### Prerequisites
+
+```
+REGION=us-west-2
+CLUSTER_NAME=eksworkshop-eksctl
+VPC_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query "cluster.resourcesVpcConfig.vpcId" --output text)
+SUBNET_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query "cluster.resourcesVpcConfig.subnetIds[0]" --output text)
+SECURITY_GROUP_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query "cluster.resourcesVpcConfig.securityGroupIds" --output text)
+CIDR_BLOCK=$(aws ec2 describe-vpcs --vpc-ids $VPC_ID --query "Vpcs[].CidrBlock" --output text)
+S3_LOGS_BUCKET=eks-fsx-lustre-$(cat /dev/urandom | LC_ALL=C tr -dc "[:alpha:]" | tr '[:upper:]' '[:lower:]' | head -c 32)
+```
+
+
+You must have:
+
+   * Version 1.18.163 or later of the AWS CLI installed. You can check your currently-installed version with the aws --version command. To install or upgrade the AWS CLI, see Installing the AWS CLI.
+
+   * An existing Amazon EKS cluster. If you don't currently have a cluster, see Getting started with Amazon EKS to create one.
+
+   * Version 0.31.0-rc.0 or later of eksctl installed. You can check your currently-installed version with the eksctl version command. To install or upgrade eksctl, see Installing or upgrading eksctl.
+
+   * The latest version of kubectl installed that aligns to your cluster version. You can check your currently-installed version with the kubectl version --short --client command. For more information, see Installing kubectl.
+
+#### To deploy the Amazon FSx for Lustre CSI driver to an Amazon EKS cluster
+
+1. Create an AWS Identity and Access Management OIDC provider and associate it with your cluster.
+    ```
+    eksctl utils associate-iam-oidc-provider \
+        --region <region-code> \
+        --cluster <prod> \
+        --approve
+    ```
+
+    - Create an IAM policy and service account that allows the driver to make calls to AWS APIs on your behalf.
+
+        ```
+        cat > fsx-csi-driver.json
+        ```
+        Copy the following text and save it to a file named fsx-csi-driver.json.
+
+        ```
+    "Version":"2012-10-17",
+        "Statement":[
+            {
+                "Effect":"Allow",
+                "Action":[
+                    "iam:CreateServiceLinkedRole",
+                    "iam:AttachRolePolicy",
+                    "iam:PutRolePolicy"
+                ],
+                "Resource":"arn:aws:iam::*:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*"
+            },
+            {
+                "Action":"iam:CreateServiceLinkedRole",
+                "Effect":"Allow",
+                "Resource":"*",
+                "Condition":{
+                    "StringLike":{
+                    "iam:AWSServiceName":[
+                        "fsx.amazonaws.com"
+                    ]
+                    }
+                }
+            },
+            {
+                "Effect":"Allow",
+                "Action":[
+                    "s3:ListBucket",
+                    "fsx:CreateFileSystem",
+                    "fsx:DeleteFileSystem",
+                    "fsx:DescribeFileSystems"
+                ],
+                "Resource":[
+                    "*"
+                ]
+            }
+        ]
+        }
+        ```
+
+2. Create the policy.
+```
+    aws iam create-policy \
+        --policy-name <Amazon_FSx_Lustre_CSI_Driver> \
+        --policy-document file://fsx-csi-driver.json
+```
+    *Take note of the policy Amazon Resource Name (ARN) that is returned.*
+
+3. Create a Kubernetes service account for the driver and attach the policy to the service account. Replacing the ARN of the policy with the ARN returned in the previous step.
+    ```
+    eksctl create iamserviceaccount \
+        --region <region-code> \
+        --name fsx-csi-controller-sa \
+        --namespace kube-system \
+        --cluster <prod> \
+        --attach-policy-arn arn:aws:iam::<111122223333:policy/Amazon_FSx_Lustre_CSI_Driver> \
+        --approve
+    ```
+
+    **Output:**
+
+    You'll see several lines of output as the service account is created. The last line of output is similar to the following example line.
+
+    ```
+    [ℹ]  created serviceaccount "kube-system/fsx-csi-controller-sa"
+    ```
+
+    Note the name of the AWS CloudFormation stack that was deployed. In the example output above, the stack is named eksctl-prod-addon-iamserviceaccount-kube-system-fsx-csi-controller-sa.
+
+4. Note the Role ARN for the role that was created.
+
+   - Open the AWS CloudFormation console at https://console.aws.amazon.com/cloudformation
+    
+   - Ensure that the console is set to the Region that you created your IAM role in and then select Stacks.
+
+   - Select the stack named eksctl-prod-addon-iamserviceaccount-kube-system-fsx-csi-controller-sa.
+
+   - Select the Outputs tab. The Role ARN is listed on the Output(1) page.
+
+5. Deploy the driver with the following command.
+
+    ```
+    kubectl apply -k "github.com/kubernetes-sigs/aws-fsx-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+    ```
+    **Output:**
+
+    ```
+    Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
+    serviceaccount/fsx-csi-controller-sa configured
+    clusterrole.rbac.authorization.k8s.io/fsx-csi-external-provisioner-role created
+    clusterrolebinding.rbac.authorization.k8s.io/fsx-csi-external-provisioner-binding created
+    deployment.apps/fsx-csi-controller created
+    daemonset.apps/fsx-csi-node created
+    csidriver.storage.k8s.io/fsx.csi.aws.com created
+    ```
+
+6. Patch the driver deployment to add the service account that you created in step 3, replacing the ARN with the ARN that you noted in step 4.
+
+```
+kubectl annotate serviceaccount -n kube-system <fsx-csi-controller-sa> \
+ eks.amazonaws.com/role-arn=<arn:aws:iam::111122223333:role/eksctl-prod-addon-iamserviceaccount-kube-sys-Role1-NPFTLHJ5PJF5> --overwrite=true
+```
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a new module to setup FSx Lustre CSI for EKS and installs a small app that tests PVC and S3 import/export

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
