### PR TITLE
fix: broken aws-load-balancer-controller/crds link

### DIFF
--- a/content/beginner/130_exposing-service/cleaning.md
+++ b/content/beginner/130_exposing-service/cleaning.md
@@ -21,7 +21,7 @@ curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-cont
 helm uninstall aws-load-balancer-controller \
     -n kube-system
 
-kubectl delete -k github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master
+kubectl delete -f https://raw.githubusercontent.com/aws/eks-charts/master/stable/aws-load-balancer-controller/crds/crds.yaml
 
 eksctl delete iamserviceaccount \
     --cluster eksworkshop-eksctl \

--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -103,7 +103,7 @@ eksctl create iamserviceaccount \
 #### Install the TargetGroupBinding CRDs
 
 ```bash
-kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master
+kubectl apply -f https://raw.githubusercontent.com/aws/eks-charts/master/stable/aws-load-balancer-controller/crds/crds.yaml
 
 kubectl get crd
 ```


### PR DESCRIPTION
*Issue #, if available:*
`no matches found: github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master` when apply `kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master
`
*Description of changes:*
Change to use crds github raw file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
