### PR TITLE
Correct was-node ConfigMap typo

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
@@ -25,7 +25,7 @@ kubectl get pods -n kube-system -w
 ```
 ### Configure Custom networking
 
-Edit aws-node configmap and add AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG environment variable to the node container spec and set it to true
+Edit aws-node DaemonSet and add AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG environment variable to the node container spec and set it to true
 
 Note: You only need to set one environment variable in the CNI daemonset configuration:
 ```


### PR DESCRIPTION
*Issue #993*

*Description of changes:*

Fixed typo of editing aws-node configmap to aws-node daemonset


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
