### PR TITLE
Suppress FutureWarning messages from TensorFlow

### DIFF
--- a/content/advanced/420_kubeflow/kubeflow.files/inference_client.py
+++ b/content/advanced/420_kubeflow/kubeflow.files/inference_client.py
@@ -1,6 +1,13 @@
 # TensorFlow and tf.keras
-import tensorflow as tf
-from tensorflow import keras
+# Workaround to suppress FutureWarnings messages ref: https://www.cicoria.com/tensorflow-suppressing-futurewarning-numpy-messages-in-jupyter-notebooks/
+import warnings  
+with warnings.catch_warnings():  
+    warnings.filterwarnings("ignore",category=FutureWarning)
+    import tensorflow as tf
+    from tensorflow import keras
+    from tensorflow.keras.preprocessing.text import Tokenizer
+#import tensorflow as tf
+#from tensorflow import keras
 
 # Helper libraries
 import numpy as np


### PR DESCRIPTION
There is an issue running Tensorflow that shows a ver big list of "FutureWarning" deprecations messages that falls out of the scope of our workshop.

The change will suppress those warnings as they might confuse the readers and are out of scope of the workshop.

Source here... https://www.cicoria.com/tensorflow-suppressing-futurewarning-numpy-messages-in-jupyter-notebooks/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
