### PR TITLE
Option to increase Cloud9 disk size

### DIFF
--- a/content/020_prerequisites/workspace.md
+++ b/content/020_prerequisites/workspace.md
@@ -52,3 +52,45 @@ When it comes up, customize the environment by:
 ![c9newtab](/images/prerequisites/cloud9-3.png)
 - Your workspace should now look like this
 ![c9after](/images/prerequisites/cloud9-4.png)
+
+{{% notice info %}}
+If you intend to run all the sections in this workshop, it will be useful to have more storage available for all the repositories and tests.
+{{% /notice %}}
+
+### Increase the disk size on the Cloud9 instance
+
+```bash
+pip install --user --upgrade boto3
+export instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+python -c "import boto3
+import os
+from botocore.exceptions import ClientError 
+ec2 = boto3.client('ec2')
+volume_info = ec2.describe_volumes(
+    Filters=[
+        {
+            'Name': 'attachment.instance-id',
+            'Values': [
+                os.getenv('instance_id')
+            ]
+        }
+    ]
+)
+volume_id = volume_info['Volumes'][0]['VolumeId']
+try:
+    resize = ec2.modify_volume(    
+            VolumeId=volume_id,    
+            Size=30
+    )
+    print(resize)
+except ClientError as e:
+    if e.response['Error']['Code'] == 'InvalidParameterValue':
+        print('ERROR MESSAGE: {}'.format(e))"
+if [ $? -eq 0 ]; then
+    sudo reboot
+fi
+
+```
+
+- *Note*: The above command is adding more disk space to the root volume of the EC2 instance that Cloud9 runs on. Once the command completes, we reboot the instance which could take a minute or two for the IDE to come back online.
+


### PR DESCRIPTION
I had issues installing Tensorflow after running several of the modules on Cloud9. The reason behind that failure was the lack of space on the Cloud9 environment.

I copied the script from ECS Workshop, I think is very elegant and simple way to increase the size of the disk until Cloud9 allow to add an additional disk from creation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
