### PR TITLE
Missing dependency for inference_client.py

### DIFF
--- a/content/advanced/420_kubeflow/inference.md
+++ b/content/advanced/420_kubeflow/inference.md
@@ -46,7 +46,7 @@ Install `tensorflow` package:
 ```
 curl -O https://bootstrap.pypa.io/get-pip.py
 python3 get-pip.py --user
-pip3 install tensorflow --user
+pip3 install requests tensorflow --user
 ```
 
 #### Run inference


### PR DESCRIPTION
Added a missing dependency required by the inference_client.py to the install line. Error on my environment was:

 File "inference_client.py", line 13, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
