### PR TITLE
Update ingress_controller_alb.md

### DIFF
--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -38,7 +38,7 @@ ALB supports multiple features including:
 
 #### Prerequisites
 
-We will verify if the AWS Load Balancer Controller version has beed set
+We will verify if the AWS Load Balancer Controller version has been set
 
 ```bash
 if [ ! -x ${LBC_VERSION} ]
@@ -103,7 +103,7 @@ eksctl create iamserviceaccount \
 #### Install the TargetGroupBinding CRDs
 
 ```bash
-kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master
+kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds?ref=master
 
 kubectl get crd
 ```


### PR DESCRIPTION
Fix several typos

*Issue #, if available:*

*Description of changes:*

Fix double slash of `kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master`
Fix `beed` to `been`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
