### PR TITLE
kube-ops-view helm repo

### DIFF
--- a/content/beginner/080_scaling/install_kube_ops_view.md
+++ b/content/beginner/080_scaling/install_kube_ops_view.md
@@ -14,6 +14,7 @@ We will deploy kube-ops-view using `Helm` configured in a previous [module](/beg
 The following line updates the stable helm repository and then installs kube-ops-view using a LoadBalancer Service type and creating a RBAC (Resource Base Access Control) entry for the read-only service account to read nodes and pods information from the cluster.
 
 ```
+helm repo add stable https://charts.helm.sh/stable
 helm install kube-ops-view \
 stable/kube-ops-view \
 --set service.type=LoadBalancer \


### PR DESCRIPTION
The chars stable helm repo need to be added to helm before installing this chart

added `helm repo add stable https://charts.helm.sh/stable` before the install command

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
