### PR TITLE
Fix the "kubectl get sa ..." command

### DIFF
--- a/content/beginner/180_fargate/prerequisites-for-alb.md
+++ b/content/beginner/180_fargate/prerequisites-for-alb.md
@@ -76,7 +76,7 @@ The above command deploys a CloudFormation template that creates an IAM role and
 The IAM role gets associated with a Kubernetes Service Account. You can see details of the service account created with the following command.
 
 ```bash
-kubectl get sa alb-ingress-controller -n 2048-game -o yaml
+kubectl get sa aws-load-balancer-controller -n kube-system -o yaml
 ```
 
 {{% notice info %}}


### PR DESCRIPTION
Fixed the `kubectl get sa aws-load-balancer-controller ...` command (older sa name and wrong namespace)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
