### PR TITLE
Fix fargate

### DIFF
--- a/content/beginner/180_fargate/deploying-fargate.md
+++ b/content/beginner/180_fargate/deploying-fargate.md
@@ -5,7 +5,7 @@ weight: 13
 draft: false
 ---
 
-## Deploy the sample application
+### Deploy the sample application
 
 Deploy the game [2048](https://play2048.co/) as a sample application to verify that the AWS Load Balancer Controller creates an Application Load Balancer as a result of the Ingress object.
 
@@ -13,7 +13,7 @@ Deploy the game [2048](https://play2048.co/) as a sample application to verify t
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full.yaml
 ```
 
-You can check if a Deployment has completed
+You can check if the `deployment` has completed
 
 ```bash
 kubectl -n game-2048 rollout status deployment deployment-2048

--- a/content/beginner/180_fargate/ingress.md
+++ b/content/beginner/180_fargate/ingress.md
@@ -5,7 +5,7 @@ weight: 15
 draft: false
 ---
 
-## Ingress
+### Ingress
 
 After few seconds, verify that the Ingress resource is enabled:
 

--- a/content/beginner/180_fargate/prerequisites-for-alb.md
+++ b/content/beginner/180_fargate/prerequisites-for-alb.md
@@ -86,7 +86,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::197520326489:role/eksctl-eksworkshop-eksctl-addon-iamserviceac-Role1-1MMJRJ4LWWHD8
+    eks.amazonaws.com/role-arn: arn:aws:iam::<AWS_ACCOUNT_ID>:role/eksctl-eksworkshop-eksctl-addon-iamserviceac-Role1-1MMJRJ4LWWHD8
   creationTimestamp: "2020-12-04T19:31:57Z"
   name: aws-load-balancer-controller
   namespace: kube-system

--- a/content/beginner/180_fargate/prerequisites.md
+++ b/content/beginner/180_fargate/prerequisites.md
@@ -13,6 +13,7 @@ AWS Fargate with Amazon EKS is currently  available in the following Regions:
 | US East (N. Virginia) | us-east-1 |
 | US West (N. California) | us-west-1 |
 | US West (Oregon) | us-west-2 |
+| Africa (Cape Town) | af-south-1 |
 | Asia Pacific (Hong Kong) | ap-east-1 |
 | Asia Pacific (Mumbai) | ap-south-1 |
 | Asia Pacific (Seoul) | ap-northeast-2 |
@@ -23,11 +24,11 @@ AWS Fargate with Amazon EKS is currently  available in the following Regions:
 | Europe (Frankfurt) | eu-central-1 |
 | Europe (Ireland) | eu-west-1 |
 | Europe (London) | eu-west-2 |
+| Europe (Milan) | eu-south-1 |
 | Europe (Paris) | eu-west-3 |
 | Europe (Stockholm) | eu-north-1 |
 | South America (São Paulo) | sa-east-1 |
 | Middle East (Bahrain) | me-south-1 |
-
 
 {{% notice warning %}}
 Don't continue the lab unless you use one of these region.


### PR DESCRIPTION
*Issue #, if available:*
#1009 
#1003 
*Description of changes:*
When creating a Fargate only cluster, we need to specify the AWS_REGION and the VPC ID

* Updated the helm charts deployment
* Small update based on linter best practice
* Update the region list
* Added some missing output from commands ran during the lab

Tested on a vanilla eksworkshop EKS cluster (EC2) and on a vanilla Fargate only EKS cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
