### PR TITLE
Update jenkins

### DIFF
--- a/content/intermediate/210_jenkins/cleanup.md
+++ b/content/intermediate/210_jenkins/cleanup.md
@@ -8,6 +8,7 @@ To uninstall Jenkins and cleanup the service account and CodeCommit repository r
 
 ```
 helm uninstall cicd
+helm repo remove jenkins
 aws codecommit delete-repository --repository-name eksworkshop-app
 aws iam detach-user-policy --user-name git-user --policy-arn arn:aws:iam::aws:policy/AWSCodeCommitPowerUser
 aws iam delete-service-specific-credential --user-name git-user --service-specific-credential-id $CREDENTIAL_ID

--- a/content/intermediate/210_jenkins/deploy.md
+++ b/content/intermediate/210_jenkins/deploy.md
@@ -41,7 +41,8 @@ EOF
 Now we'll use the `helm` cli to create the Jenkins server as we've declared it in the `values.yaml` file.
 
 ```
-helm install cicd stable/jenkins -f values.yaml
+helm repo add jenkins https://charts.jenkins.io
+helm install cicd jenkins/jenkins -f values.yaml
 ```
 
 The output of this command will give you some additional information such as the

--- a/content/intermediate/210_jenkins/deploy.md
+++ b/content/intermediate/210_jenkins/deploy.md
@@ -16,7 +16,7 @@ We'll begin by creating the `values.yaml` to declare the configuration of our Je
 ```
 cat << EOF > values.yaml
 ---
-master:
+controller:
   additionalPlugins:
     - aws-codecommit-jobs:0.3.0
   resources:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
I follow the workshop to run stable/jenkins chart and see:
```
The Jenkins chart is deprecated. Future development has been moved to https://github.com/jenkinsci/helm-charts
```
So I changed the workshop to use jenkins repo instead. Also, I updated the value.yaml because in jenkins/values.yaml it's "controller" not "master". See https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml

Confirmed I can use jenkins repo to finish the workshop without error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
