### PR TITLE
add curly brackets to ACCOUNT_ID variable to get correct rolearn

### DIFF
--- a/content/intermediate/220_codepipeline/configmap.md
+++ b/content/intermediate/220_codepipeline/configmap.md
@@ -11,7 +11,7 @@ for the EKS cluster.
 Once the ConfigMap includes this new role, kubectl in the CodeBuild stage of the pipeline will be able to interact with the EKS cluster via the IAM role.
 
 ```
-ROLE="    - rolearn: arn:aws:iam::$ACCOUNT_ID:role/EksWorkshopCodeBuildKubectlRole\n      username: build\n      groups:\n        - system:masters"
+ROLE="    - rolearn: arn:aws:iam::${ACCOUNT_ID}:role/EksWorkshopCodeBuildKubectlRole\n      username: build\n      groups:\n        - system:masters"
 
 kubectl get -n kube-system configmap/aws-auth -o yaml | awk "/mapRoles: \|/{print;print \"$ROLE\";next}1" > /tmp/aws-auth-patch.yml
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28039402/101245621-0cb10480-3749-11eb-9862-8363675e6d30.png)
The provided script won't correctly generate the rolearn.(Cause by `:r`), Fix it by adding brackets to ACCOUNT_ID.

*Issue #, if available:*
N/A
*Description of changes:*
Add curly brackets to ACCOUNT_ID variable to fix this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
