### PR TITLE
Update helm commands for aws-load-balancer-controller

### DIFF
--- a/content/beginner/180_fargate/prerequisites-for-alb.md
+++ b/content/beginner/180_fargate/prerequisites-for-alb.md
@@ -139,8 +139,8 @@ helm upgrade -i aws-load-balancer-controller \
     --set serviceAccount.create=false \
     --set serviceAccount.name=aws-load-balancer-controller \
     --set image.tag="${LBC_VERSION}" \
-    --set awsRegion=${AWS_REGION} \
-    --set awsVpcID=${VPC_ID}
+    --set region=${AWS_REGION} \
+    --set vpcId=${VPC_ID}
 ```
 
 You can check if the `deployment` has completed


### PR DESCRIPTION
As referred in eks-charts for [aws-load-balancer-controller](https://github.com/aws/eks-charts/tree/master/stable/aws-load-balancer-controller#configuration) there is a change in helm variable names for `awsRegion` and `awsVpcID` to `region` and `vpcId` respectively

```
helm upgrade -i aws-load-balancer-controller \
    eks/aws-load-balancer-controller \
    -n kube-system \
    --set clusterName=eksworkshop-eksctl \
    --set serviceAccount.create=false \
    --set serviceAccount.name=aws-load-balancer-controller \
    --set image.tag="${LBC_VERSION}" \
    --set region=${AWS_REGION} \
    --set vpcId=${VPC_ID}
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
