### PR TITLE
Fixing yq install

### DIFF
--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -40,7 +40,7 @@ sudo yum -y install jq gettext bash-completion moreutils
 
 ```bash
 echo 'yq() {
-  docker run --rm -i -v "${PWD}":/workdir mikefarah/yq yq "$@"
+  docker run --rm -i -v "${PWD}":/workdir mikefarah/yq "$@"
 }' | tee -a ~/.bashrc && source ~/.bashrc
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removing the additional "yq" as it caused the yq command to not run properly. 
Before it was equivalent to `yq yq <command> [flags] ...` but now should run as `yq <command> [flags] ...`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
