### PR TITLE
added EKS Networking Workshops to config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -83,14 +83,19 @@ url = "https://ecsworkshop.com"
 weight = 8
 
 [[menu.shortcuts]]
+name = "<i class='fas fa-chalkboard'></i> EKS Networking Workshops"
+url = "https://awsk8snetworkshops.com"
+weight = 9
+
+[[menu.shortcuts]]
 name = "<i class='fas fa-chalkboard'></i> AWS Partner Workshops"
 url = "https://awsworkshop.io"
-weight = 9
+weight = 10
 
 [[menu.shortcuts]]
 name = "<i class='fas fa-bookmark'></i> More Resources"
 url = "/more_resources"
-weight = 10
+weight = 15
 
 [[menu.shortcuts]]
 name = "<i class='fas fa-users'></i> Authors"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added EKS Networking Workshops to `config.toml` for better discoverability and reach for the networking workshop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
