### PR TITLE
Update launcheks.md to use k8s 1.18

### DIFF
--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -32,7 +32,7 @@ If you do see the correct role, proceed to next step to create an EKS cluster.
 ### Create an EKS cluster
 
 {{% notice warning %}}
-`eksctl` version must be 0.24.0 or above to deploy EKS 1.17, [click here](/030_eksctl/prerequisites) to get the latest version.
+`eksctl` version must be 0.30.0 or above to deploy EKS 1.18, [click here](/030_eksctl/prerequisites) to get the latest version.
 {{% /notice %}}
 
 Create an eksctl deployment file (eksworkshop.yaml) use in creating your cluster using the following syntax:
@@ -46,7 +46,7 @@ kind: ClusterConfig
 metadata:
   name: eksworkshop-eksctl
   region: ${AWS_REGION}
-  version: "1.17"
+  version: "1.18"
 
 availabilityZones: ["${AWS_REGION}a", "${AWS_REGION}b", "${AWS_REGION}c"]
 


### PR DESCRIPTION
Since version 0.32.0 eksctl now deploys eks 1.18 by default.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
