### PR TITLE
Added a new chapter to do a full cluster upgrade

### DIFF
--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -69,6 +69,10 @@ EOF
 
 Next, use the file you created as the input for the eksctl cluster creation.
 
+{{% notice info %}}
+We are deliberatly launching one version behind the latest (1.17 vs. 1.18) to allow you to perform a cluster upgrade in one of the Chapters.
+{{% /notice %}}
+
 ```bash
 eksctl create cluster -f eksworkshop.yaml
 ```

--- a/content/intermediate/320_eks_upgrades/_index.md
+++ b/content/intermediate/320_eks_upgrades/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Patching/Upgrading your EKS Cluster"
+chapter: true
+weight: 320
+draft: false
+tags:
+  - intermediate
+  - operations
+---
+
+# Patching/Upgrading your EKS Cluster
+
+As EKS tracks upstream Kubernetes that means that customers can, and should, regularly upgrade their EKS so as to stay within the project's upstream support window. This used to be the current version and two version back (n-2) - but it was [recently extended to three versions back (n-3)](https://kubernetes.io/blog/2020/08/31/kubernetes-1-19-feature-one-year-support/). 
+
+There is a new major version of Kubernetes every quarter which means that the Kubernetes support window has now gone from three quarters of a year to one full year.
+
+In addition to upgrades to Kuberentes, there are other related upgrades to think about with your cluster as well:
+
+- The Amazon Machine Image (AMI) of your Nodes - including not just the portion of Kubernetes that is part of the image, the kubelet, but everything else there (OS, containerd, etc.). The control plane always supports managing kubelets that are one version behind itself (n-1) to help faciliatet this upgrade.
+- The foundational DaemonSets that are on deployed onto every EKS cluster (kube-proxy, CoreDNS and the AWS CNI) which may need to be upgraded as you upgrade Kubernetes. Our documentation [tells you](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#w665aac14c15b5c17) if this is required and which versions you should upgrade to.
+- And any Add-ons/Controllers/Drivers that you've added to extend Kubernetes and provide important cluster functionality may need to be upgraded as you upgrade Kuberentes
+
+In this Chapter you'll follow the AWS suggested process to upgrade your cluster from 1.17 to 1.18 including its Managed Node Group to get first-hand experience with this process and where EKS and Managed Node Groups help.

--- a/content/intermediate/320_eks_upgrades/theprocess.md
+++ b/content/intermediate/320_eks_upgrades/theprocess.md
@@ -1,0 +1,12 @@
+---
+title: "The Upgrade Process"
+weight: 321
+---
+
+The process goes as follows:
+
+1. (Optional) Check if the new version you are upgrading to has any API deprecations which will mean that you'll need to change your YAML Spec files for them to continue to work on the new cluster. This is only the case with some version upgrades such as [1.15 to 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). There are various tools that can help with this such as [kube-no-trouble](https://github.com/doitintl/kube-no-trouble). Since there are not any such deprecations going from 1.17 to 1.18 we'll skip this step here.
+1. Run a `kubectl get nodes` and ensure that all of your Nodes are running the current version. Kubernetes can only support nodes that are one version behind - meaning they all need to match the current Kubernetes version so when you upgrade the EKS control plane they'll then only be one version behind. For Fargate relaunching a Pod (maybe by deleted it and letting the ReplicaSet replace it) will bring it in line with the current Kubernetes version.
+1. Upgrade the EKS Control Plane to the new major version
+1. Check if the core add-ons (kubeproxy, CoreDNS and the CNI) that ship with EKS require an upgrade to conincide with the major version upgrade. This will be in our [upgrade documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#w665aac14c15b5c17). If so follow that documentation to upgrade those. In this case (a 1.17 to 1.18 upgrade) the documentation says we'll need to upgrade both CoreDNS and kubeproxy.
+1. Upgrade any worker nodes so that the kubelet on them (which will now be one Kubernete major version behind) matches that of the EKS control plane. While you don't have to do this immediatly it is a good idea to have the Nodes on the same version as the control plane as soon as is practical - plus it will make Step 2 easier the next time you have to upgrade. If you are using Managed Node Groups (as we are here) then EKS can help facilitate this with a safe automated process which orchestrates both the AWS and Kubernetes side of a rolling Node replacement/upgrade. If you are using Fargate then this will happen automatically the next time your Pods are replaced.

--- a/content/intermediate/320_eks_upgrades/upgradeaddons.md
+++ b/content/intermediate/320_eks_upgrades/upgradeaddons.md
@@ -1,0 +1,28 @@
+---
+title: "Upgrade EKS Core Add-ons"
+weight: 323
+---
+
+When you provision an EKS cluster you get three add-ons that run on top of the cluster and that are required for it to function properly:
+- kubeproxy
+- CoreDNS
+- aws-node (AWS CNI or Network Plugin)
+
+Looking at the the [upgrade documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#w665aac14c15b5c17) for our 1.17 to 1.18 upgrade we see that we'll need to upgrade the kubeproxy and CoreDNS. In addition to performing these steps manually with kubectl as documented there you'll find that eksctl can do it for you as well.
+
+Since we are using eksctl in the workshop we'll run the two necessary commands for it to do these updates for us:
+```bash
+eksctl utils update-kube-proxy --cluster=eksworkshop-eksctl --approve
+```
+
+and then
+
+```bash
+eksctl utils update-coredns --cluster=eksworkshop-eksctl --approve
+```
+
+We can confirm we succeeded by retrieving the versions of each with the commands:
+```bash
+kubectl get daemonset kube-proxy --namespace kube-system -o=jsonpath='{$.spec.template.spec.containers[:1].image}'
+kubectl describe deployment coredns --namespace kube-system | grep Image | cut -d "/" -f 3
+```

--- a/content/intermediate/320_eks_upgrades/upgradeeks.md
+++ b/content/intermediate/320_eks_upgrades/upgradeeks.md
@@ -1,0 +1,38 @@
+---
+title: "Upgrade EKS Control Plane"
+weight: 322
+---
+
+The first step of this process is to upgrade the EKS Control Plane.
+
+Since we used eksctl to provision our cluster we'll use that tool to do our upgrade as well.
+
+First we'll run this command
+```bash
+eksctl upgrade cluster --name=eksworkshop-eksctl
+```
+
+You'll see in the output that it found our cluster, worked out that it is 1.17 and the next version is 1.18 (you can only go to the next version with EKS) and that everything is ready for us to proceed with an upgrade.
+```
+$ eksctl upgrade cluster --name=eksworkshop-eksctl
+[ℹ]  eksctl version 0.36.0
+[ℹ]  using region ap-southeast-2
+[ℹ]  (plan) would upgrade cluster "eksworkshop-eksctl" control plane from current version "1.17" to "1.18"
+[ℹ]  re-building cluster stack "eksctl-eksworkshop-eksctl-cluster"
+[✔]  all resources in cluster stack "eksctl-eksworkshop-eksctl-cluster" are up-to-date
+[ℹ]  checking security group configuration for all nodegroups
+[ℹ]  all nodegroups have up-to-date configuration
+[!]  no changes were applied, run again with '--approve' to apply the changes
+```
+
+We'll run it again with an --approve appended to proceed
+```bash
+eksctl upgrade cluster --name=eksworkshop-eksctl --approve
+```
+{{% notice info %}}
+This process should take approximately 25 minutes. You can continue to use the cluster during the control plane upgrade process but you might experience minor service interruptions. For example, if you attempt to connect to one of the EKS API servers just before or just after it's terminated and replaced by a new API server running the new version of Kubernetes, you might experience temporary API call errors or connectivity issues. If this happens, retry your API operations until they succeed. Your existing Pods/workloads running in the data plane should not experience any interruption during the control plane upgrade.
+{{% /notice %}}
+
+{{% notice info %}}
+Given how long this step will take and that the cluster will continue to work maybe move on to other workshop chapters until this process completes then come back to finish once it completes.
+{{% /notice %}}

--- a/content/intermediate/320_eks_upgrades/upgrademng.md
+++ b/content/intermediate/320_eks_upgrades/upgrademng.md
@@ -1,0 +1,41 @@
+---
+title: "Upgrade Managed Node Group"
+weight: 324
+---
+
+Finally we have gotten to the last step of the upgrade process which is upgrading our Nodes.
+
+There are two ways to provision and manage your worker nodes - self-managed node groups and managed node groups. In this workshop eksctl was configured to use the managed node groups. This was helpful here as managed node groups make this easier for us by automating both the AWS and the Kubernetes side of the process.
+
+The way that managed node groups does this is:
+
+1. Amazon EKS creates a new Amazon EC2 launch template version for the Auto Scaling group associated with your node group. The new template uses the target AMI for the update.
+1. The Auto Scaling group is updated to use the latest launch template with the new AMI.
+1. The Auto Scaling group maximum size and desired size are incremented by one up to twice the number of Availability Zones in the Region that the Auto Scaling group is deployed in. This is to ensure that at least one new instance comes up in every Availability Zone in the Region that your node group is deployed in.
+1. Amazon EKS checks the nodes in the node group for the eks.amazonaws.com/nodegroup-image label, and applies a eks.amazonaws.com/nodegroup=unschedulable:NoSchedule taint on all of the nodes in the node group that aren't labeled with the latest AMI ID. This prevents nodes that have already been updated from a previous failed update from being tainted.
+1. Amazon EKS randomly selects a node in the node group and evicts all pods from it.
+1. After all of the pods are evicted, Amazon EKS cordons the node. This is done so that the service controller doesn't send any new request to this node and removes this node from its list of healthy, active nodes.
+1. Amazon EKS sends a termination request to the Auto Scaling group for the cordoned node.
+1. Steps 5-7 are repeated until there are no nodes in the node group that are deployed with the earlier version of the launch template.
+1. The Auto Scaling group maximum size and desired size are decremented by 1 to return to your pre-update values.
+
+{{% notice info %}}
+If we instead had used a self-managed node group then we need to do the Kubernetes taint and draining steps ourselves to ensure Kubernetes knows that Node is going away and can manage that process gracefully in order for such an upgrade to be non-disruptive.
+{{% /notice %}}
+
+The first step only applies to if we are using the cluster autoscaler. We don't want conflicting Node scaling actions during our upgrade so we should scale that to zero to suspend it during this process using the command below. Unless you have done that chapter in the workshop and left it deployed you can skip this step.
+
+```bash
+kubectl scale deployments/cluster-autoscaler --replicas=0 -n kube-system
+```
+
+We can then trigger the MNG upgrade process by running the following eksctl command:
+```bash
+eksctl upgrade nodegroup --name=nodegroup --cluster=eksworkshop-eksctl --kubernetes-version=1.18
+```
+
+In another Terminal tab you can follow the progress with:
+```bash
+kubectl get nodes --watch
+```
+You'll notice the new nodes come up (three one in each AZ), one of the older nodes go STATUS SchedulingDisabled, then eventually that node go away and another new node come up to replace it and so on as described in the process above until all the old Nodes have gone away. Then it'll scale back down from 6 Nodes to the original 3.


### PR DESCRIPTION
I've added a new chapter that will show how to take this cluster from 1.17 to 1.18 with eksctl. I also added a note to the cluster provisioning step indicating why it is one version behind kind of as a reminder for people to not try to make that current so that we can have this upgrade chapter going forward.