### PR TITLE
Move the other OPA example into 310_opa_gatekeeper.

### DIFF
--- a/content/intermediate/310_opa_gatekeeper/policy_example_2.md
+++ b/content/intermediate/310_opa_gatekeeper/policy_example_2.md
@@ -1,6 +1,6 @@
 ---
-title: "OPA Policy Example 1: Approved container registry policy"
-weight: 20
+title: "OPA Policy Example 2: Approved container registry policy"
+weight: 25
 draft: false
 ---
 


### PR DESCRIPTION
*Description of changes:*
- Somehow that example was outside the section of OPA Gatekeeper
  and appeared in the main tree of Intermediate content.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
