### PR TITLE
Remove hardcoded pod name

### DIFF
--- a/content/advanced/320_servicemesh_with_appmesh/port_to_app_mesh/trigger_sidecar_injection.md
+++ b/content/advanced/320_servicemesh_with_appmesh/port_to_app_mesh/trigger_sidecar_injection.md
@@ -46,7 +46,9 @@ metal-v1-9f78fb8c8-67mqc   2/2     Running   0          14s
 Now you can see that 2 containers are running in each pod, verify that they are the application service and the Envoy proxy. Examine the pod and confirm these are the containers running within it.
 
 ```bash
-kubectl -n prod get pods dj-6544487b5f-7glpg -o jsonpath='{.spec.containers[*].name}'
+export DJ_POD_NAME=$(kubectl get pods -n prod -l app=dj -o jsonpath='{.items[].metadata.name}')
+
+kubectl -n prod get pods $DJ_POD_NAME -o jsonpath='{.spec.containers[*].name}'
 ```
 
 {{< output >}}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Removed a hardcoded pod name and replaced it with a dynamic command to fetch it from the Kubernetes API.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
