### PR TITLE
update gatekeeper docs

### DIFF
--- a/content/intermediate/310_opa_gatekeeper/setup.md
+++ b/content/intermediate/310_opa_gatekeeper/setup.md
@@ -8,7 +8,7 @@ In this section, we will setup `OPA Gatekeeper` within the cluster.
 
 #### 1. Deploy OPA Gatekeeper using Prebuilt docker images
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.1/deploy/gatekeeper.yaml
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.3/deploy/gatekeeper.yaml
 
 ```
 
@@ -28,8 +28,8 @@ gatekeeper-controller-manager-744cdc8556-wwrb6   1/1     Running   0          25
 
 You can follow the OPA logs to see the webhook requests being issued by the Kubernetes API server:
 ```bash
-kubectl logs -l control-plane=controller-audit -n gatekeeper-system
-kubectl logs -l control-plane=controller-manager -n gatekeeper-system
+kubectl logs -l gatekeeper.sh/operation=audit -n gatekeeper-system
+kubectl logs -l gatekeeper.sh/operation=webhook -n gatekeeper-system
 
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update GK to release 3.3 since 3.1 is not supported anymore
- `control-plane=controller-audit` label wasn't right (it's `audit-controller`), fixed labels by moving them to `gatekeeper.sh/operation` labels

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
