### PR TITLE
tighten up app mesh irsa on intermediate module

### DIFF
--- a/content/intermediate/330_app_mesh/install_app_mesh_controller/install_controller.md
+++ b/content/intermediate/330_app_mesh/install_app_mesh_controller/install_controller.md
@@ -40,12 +40,20 @@ eksctl utils associate-iam-oidc-provider \
   --cluster eksworkshop-eksctl \
   --approve
 
-# Create an IAM role for the appmesh-controller service account
+# Download the IAM policy document for the controller
+curl -o controller-iam-policy.json https://raw.githubusercontent.com/aws/aws-app-mesh-controller-for-k8s/master/config/iam/controller-iam-policy.json
+
+# Create an IAM policy for the controller from the policy document
+aws iam create-policy \
+    --policy-name AWSAppMeshK8sControllerIAMPolicy \
+    --policy-document file://controller-iam-policy.json
+
+# Create an IAM role and service account for the controller
 eksctl create iamserviceaccount \
   --cluster eksworkshop-eksctl \
   --namespace appmesh-system \
   --name appmesh-controller \
-  --attach-policy-arn  arn:aws:iam::aws:policy/AWSCloudMapFullAccess,arn:aws:iam::aws:policy/AWSAppMeshFullAccess \
+  --attach-policy-arn arn:aws:iam::$ACCOUNT_ID:policy/AWSAppMeshK8sControllerIAMPolicy  \
   --override-existing-serviceaccounts \
   --approve
 ```


### PR DESCRIPTION
This change tightens up the IRSA passages in the intermediate 'Getting Started with App Mesh' module (intermediate/330). First, move to using the more narrowly-scoped controller policy from the project repo. Second, add another IRSA for the app namespace which adds proxy authorization. Since we aren't using a Virtual Gateway nor are we using TLS, we don't need to do this... yet. The documentation says that in the future all resources will need proxy authorization, so we might as well add it now.

That said, I don't think it'll address issue #1056 . I am unable to reproduce any issues, and with the simple steps in the module, it works as expected - the sidecar proxies get their config updates from the controller and everything works as expected. Without being able to reproduce it, I'm at a loss for why someone might be having issues with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
