### PR TITLE
updated to get `current-context` for CONTEXT_NAME

### DIFF
--- a/content/intermediate/290_argocd/deploy_application.md
+++ b/content/intermediate/290_argocd/deploy_application.md
@@ -21,7 +21,7 @@ This URL will be needed when we will configure the application into ArgoCD.
 
 Connect with ArgoCD CLI using our cluster context:
 ```
-CONTEXT_NAME=`kubectl config view -o jsonpath='{.contexts[].name}'`
+CONTEXT_NAME=`kubectl config view -o jsonpath='{.current-context}'`
 argocd cluster add $CONTEXT_NAME
 ```
 


### PR DESCRIPTION
This change is needed to avoid errors while looking up the CONTEXT_NAME

*Description of changes:*

While setting the CONTEXT_NAME variable, we need to get the current context and not the first available in the array. This change fixes that by getting the current context. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
