### PR TITLE
Remove pods before deleting namespace

### DIFF
--- a/content/beginner/090_rbac/cleanup.md
+++ b/content/beginner/090_rbac/cleanup.md
@@ -10,6 +10,7 @@ Once you have completed this chapter, you can cleanup the files and resources yo
 ```bash
 unset AWS_SECRET_ACCESS_KEY
 unset AWS_ACCESS_KEY_ID
+kubectl get pods -n rbac-test -o json | jq -r '.items[0].metadata.name' | xargs -I {} kubectl delete pods {} -n rbac-test
 kubectl delete namespace rbac-test
 rm rbacuser_creds.sh
 rm rbacuser-role.yaml

--- a/content/beginner/090_rbac/cleanup.md
+++ b/content/beginner/090_rbac/cleanup.md
@@ -10,7 +10,7 @@ Once you have completed this chapter, you can cleanup the files and resources yo
 ```bash
 unset AWS_SECRET_ACCESS_KEY
 unset AWS_ACCESS_KEY_ID
-kubectl get pods -n rbac-test -o json | jq -r '.items[0].metadata.name' | xargs -I {} kubectl delete pods {} -n rbac-test
+kubectl get pods -n rbac-test -o json | jq -r '.items[0].metadata.name' | xargs -I {} kubectl delete pod {} -n rbac-test --grace-period=0 --force
 kubectl delete namespace rbac-test
 rm rbacuser_creds.sh
 rm rbacuser-role.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

EKS RBAC Workshop cleanup step is missing namespaced resource (pod) cleanup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
