### PR TITLE
Updated approximate EKS launch time

### DIFF
--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -78,5 +78,5 @@ eksctl create cluster -f eksworkshop.yaml
 ```
 
 {{% notice info %}}
-Launching EKS and all the dependencies will take approximately 15 minutes
+Launching EKS and all the dependencies will take approximately 9 minutes
 {{% /notice %}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated approximate EKS launch time to 9 minutes.
https://aws.amazon.com/about-aws/whats-new/2021/03/amazon-eks-reduces-cluster-creation-time-40-percent/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
