### PR TITLE
Fix minor error in 170_statefulset expected output

### DIFF
--- a/content/beginner/170_statefulset/testscaling.md
+++ b/content/beginner/170_statefulset/testscaling.md
@@ -163,5 +163,5 @@ kubectl -n mysql delete pvc data-mysql-2
 ```
 
 {{< output >}}
-persistentvolumeclaim "data-mysql-3" deleted
+persistentvolumeclaim "data-mysql-2" deleted
 {{< /output >}}


### PR DESCRIPTION
The command issued prior to seeing the output contained `data-mysql-2`, but the document's expected output was `data-mysql-3`.
In following this workshop, the output was `persistentvolumeclaim "data-mysql-2" deleted`

*Issue #, if available:*

*Description of changes:*
Changed the `3` to a `2` to match what was expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
