### PR TITLE
Updated Dockerfile to use AWS ECR

### DIFF
--- a/content/intermediate/260_weave_flux/app.files/Dockerfile
+++ b/content/intermediate/260_weave_flux/app.files/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:mainline-alpine
+FROM public.ecr.aws/nginx/nginx
 RUN rm /etc/nginx/conf.d/*
 ADD src/hello.conf /etc/nginx/conf.d/
 ADD src/index.html /usr/share/nginx/html/


### PR DESCRIPTION
*Issue #, if available:*
Step 1/4 : FROM nginx:mainline-alpine    mainline-alpine: Pulling from library/nginx    toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit    

*Description of changes:*
This update was made to stop Dockerhub pull rate limiting.  ECR will use the Account you are pulling from as the rate limiting factor and will avoid errors during the build in CodeBuild for this lab.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
