### PR TITLE
Update time to launch EKS clusters

### DIFF
--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -78,5 +78,5 @@ eksctl create cluster -f eksworkshop.yaml
 ```
 
 {{% notice info %}}
-Launching EKS and all the dependencies will take approximately 15 minutes
+Launching EKS and all the dependencies will take approximately 9 minutes
 {{% /notice %}}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

As per https://aws.amazon.com/about-aws/whats-new/2021/03/amazon-eks-reduces-cluster-creation-time-40-percent/

> Posted On: Mar 19, 2021
> 
> Amazon Elastic Kubernetes Service (EKS) has reduced control plane creation time by 40%, enabling you to create a new EKS cluster control plane in 9 minutes or less, on average.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
