### PR TITLE
Avoid deprecation warning in kubectl run command

### DIFF
--- a/content/beginner/130_exposing-service/connecting.md
+++ b/content/beginner/130_exposing-service/connecting.md
@@ -145,7 +145,7 @@ Creating a new deployment called _load-generator_ (with the _MyClusterIP_ variab
 
 ```bash
 # Create a new deployment and allocate a TTY for the container in the pod
-kubectl -n my-nginx run -i --tty load-generator --env="MyClusterIP=${MyClusterIP}" --image=busybox /bin/sh
+kubectl -n my-nginx run --generator=run-pod/v1 -i --tty load-generator --env="MyClusterIP=${MyClusterIP}" --image=busybox /bin/sh
 ```
 
 {{% notice tip %}}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Before:
```
Admin:~/environment $ kubectl -n my-nginx run -i --tty load-generator --env="MyClusterIP=${MyClusterIP}" --image=busybox /bin/sh
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
If you don't see a command prompt, try pressing enter.
```

After(no longer has a deprecation warning):
```
Admin:~/environment $ kubectl -n my-nginx run  --generator=run-pod/v1 -i --tty load-generator --env="MyClusterIP=${MyClusterIP}" --image=busybox /bin/sh                            
If you don't see a command prompt, try pressing enter.
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
