### PR TITLE
Update Pixie deploy directions

### DIFF
--- a/content/intermediate/241_pixie/_index.md
+++ b/content/intermediate/241_pixie/_index.md
@@ -19,7 +19,7 @@ In this chapter, we will deploy Pixie to monitor an application on a Kubernetes 
 
 ## What is Pixie?
 
-[Pixie](https://pixielabs.ai/) is an open-source observability platform for Kubernetes. It helps developers explore, monitor and debug their applications. Pixie’s features include:
+[Pixie](https://px.dev/) is an open-source observability platform for Kubernetes. It helps developers explore, monitor and debug their applications. Pixie’s features include:
 
 **Progressive instrumentation**
 

--- a/content/intermediate/241_pixie/deploy_pixie.md
+++ b/content/intermediate/241_pixie/deploy_pixie.md
@@ -20,7 +20,7 @@ bash -c "$(curl -fsSL https://withpixie.ai/install.sh)"
 
 ### Deploy Pixie
 
-Deploy Pixie to the `eksworkshop-eksctl` cluster using the CLI:
+Deploy the hosted version of Pixie to the `eksworkshop-eksctl` cluster using the CLI:
 
 ```bash
 px deploy --cluster_name eksworkshop-eksctl --pem_memory_limit=1Gi


### PR DESCRIPTION
- Point to Pixie's Open Source website (will stop redirecting to `pixielabs.ai` tomorrow at 5:30 am PST). 
- Clarify that this tutorial uses the 100% free hosted version of Pixie. Self-hosted deploy instructions coming soon. 