### PR TITLE
Upgrade awscli to v2

### DIFF
--- a/content/020_prerequisites/awscli.md
+++ b/content/020_prerequisites/awscli.md
@@ -17,7 +17,10 @@ aws --version
 
 2. Update to the latest version:
 ```
-pip install --user --upgrade awscli
+pip uninstall awscli && \
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+unzip awscliv2.zip && \
+sudo ./aws/install 
 ```
 
 3. Confirm you have a newer version:

--- a/content/020_prerequisites/awscli.md
+++ b/content/020_prerequisites/awscli.md
@@ -15,15 +15,19 @@ For this workshop, please ignore warnings about the version of pip being used.
 aws --version
 ```
 
-2. Update to the latest version:
+2. Remove v1 version:
 ```
-pip uninstall awscli && \
+pip uninstall awscli 
+```
+
+3. Upgrade to the latest version:
+```
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
 unzip awscliv2.zip && \
 sudo ./aws/install 
 ```
 
-3. Confirm you have a newer version:
+4. Confirm you have a newer version:
 ```
 aws --version
 ```

--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -27,7 +27,9 @@ sudo chmod +x /usr/local/bin/kubectl
 Upgrade AWS CLI according to guidance in [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html).
 
 ```bash
-sudo pip install --upgrade awscli && hash -r
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install 
 ```
 
 #### Install jq, envsubst (from GNU gettext utilities) and bash-completion


### PR DESCRIPTION
Due to the release of awscli v2 commands with pipes using awscli v1 are broken. A warning appears announcing the new release making some of the commands of the workshop fail.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
