### PR TITLE
Simplify EKS cluster creation using eksctl

### DIFF
--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -39,7 +39,7 @@ If you do see the correct role, proceed to next step to create an EKS cluster.
 
 >#### Option 1: Cluster configuration file (recommended)
 
-Cluster configuration file uses YAML file to represent EKS cluster properties and options to fine tune cluster behavior. Please see official documentation for schema of [cluster configuration](https://eksctl.io/usage/schema/) file.
+Cluster configuration file uses YAML file to represent EKS cluster properties and options to fine tune cluster behavior. See official documentation for schema of [cluster configuration](https://eksctl.io/usage/schema/) and [example configuration](https://github.com/weaveworks/eksctl/tree/main/examples) files.
 
 Lets create eksctl configuration file for cluster deployment
 

--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -32,50 +32,31 @@ If you do see the correct role, proceed to next step to create an EKS cluster.
 ### Create an EKS cluster
 
 {{% notice warning %}}
-`eksctl` version must be 0.24.0 or above to deploy EKS 1.17, [click here](/030_eksctl/prerequisites) to get the latest version.
+`eksctl` version must be 0.48.0 or above to deploy EKS 1.19, [click here](/030_eksctl/prerequisites) to get the latest version.
 {{% /notice %}}
 
-Create an eksctl deployment file (eksworkshop.yaml) use in creating your cluster using the following syntax:
+Create your cluster using the following syntax:
 
 ```bash
-cat << EOF > eksworkshop.yaml
----
-apiVersion: eksctl.io/v1alpha5
-kind: ClusterConfig
-
-metadata:
-  name: eksworkshop-eksctl
-  region: ${AWS_REGION}
-  version: "1.17"
-
-availabilityZones: ["${AZS[0]}", "${AZS[1]}", "${AZS[2]}"]
-
-managedNodeGroups:
-- name: nodegroup
-  desiredCapacity: 3
-  instanceType: t3.small
-  ssh:
-    enableSsm: true
-
-# To enable all of the control plane logs, uncomment below:
-# cloudWatch:
-#  clusterLogging:
-#    enableTypes: ["*"]
-
-secretsEncryption:
-  keyARN: ${MASTER_ARN}
-EOF
+eksctl create cluster \
+--name eksworkshop-eksctl \
+--version 1.19 \
+--tags cluster-type=workshop,department=dev \
+--region "${AWS_REGION}" \
+--zones "${AZS[0]},${AZS[1]},${AZS[2]}" \
+--nodes 3 \
+--node-type t3.medium \
+--node-private-networking \
+--enable-ssm \
+--managed
 ```
 
-Next, use the file you created as the input for the eksctl cluster creation.
+Here we are creating EKS cluster with managed nodes by specifying `--managed` flag. It is good practice to tag resources in AWS for easier maintenance and cost allocation purpose. `--tags` option will propagate tags to ec2 instances and ebs volumes in cluster.
+`eksctl` utility supports many other options to fine tune cluster, see [official documentation](https://eksctl.io/introduction/) to learn more about eksctl.
 
 {{% notice info %}}
-We are deliberatly launching one version behind the latest (1.17 vs. 1.18) to allow you to perform a cluster upgrade in one of the Chapters.
+We are deliberatly launching one version behind the latest (1.19 vs. 1.20) to allow you to perform a cluster upgrade in one of the Chapters.
 {{% /notice %}}
-
-```bash
-eksctl create cluster -f eksworkshop.yaml
-```
 
 {{% notice info %}}
 Launching EKS and all the dependencies will take approximately 15 minutes

--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -35,9 +35,9 @@ If you do see the correct role, proceed to next step to create an EKS cluster.
 `eksctl` version must be 0.48.0 or above to deploy EKS 1.19, [click here](/030_eksctl/prerequisites) to get the latest version.
 {{% /notice %}}
 
-`eksctl` allows you to create cluster two ways.
+`eksctl` allows you to create cluster in two ways.
 
->### Option 1: Cluster configuration file (recommended)
+>#### Option 1: Cluster configuration file (recommended)
 
 Cluster configuration file uses YAML file to represent EKS cluster properties and options to fine tune cluster behavior. Please see official documentation for schema of [cluster configuration](https://eksctl.io/usage/schema/) file.
 
@@ -81,7 +81,7 @@ eksctl create cluster -f eksworkshop.yaml
 Launching EKS and all the dependencies will take approximately 15 minutes
 {{% /notice %}}
 
->### Option 2: Create cluster using `eksctl` cli.
+>#### Option 2: Create cluster using `eksctl` cli.
 
 {{% notice info %}}
 We recommend creating cluster using configuration file. It will allow you to store configuration file in source control and keep track of changes to cluster overtime. Infrastructure as code (IaC) is preferred over manual changs.

--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -32,7 +32,7 @@ If you do see the correct role, proceed to next step to create an EKS cluster.
 ### Create an EKS cluster
 
 {{% notice warning %}}
-`eksctl` version must be 0.48.0 or above to deploy EKS 1.19, [click here](/030_eksctl/prerequisites) to get the latest version.
+`eksctl` version must be 0.48.0 or above to deploy EKS 1.17, [click here](/030_eksctl/prerequisites) to get the latest version.
 {{% /notice %}}
 
 `eksctl` allows you to create cluster in two ways.
@@ -52,7 +52,7 @@ kind: ClusterConfig
 metadata:
   name: eksworkshop-eksctl
   region: ${AWS_REGION}
-  version: "1.19"
+  version: "1.17"
   tags:
     cluster-type: workshop
     department: dev
@@ -93,7 +93,7 @@ We recommend creating cluster using configuration file. It will allow you to sto
 ```bash
 eksctl create cluster \
 --name eksworkshop-eksctl \
---version 1.19 \
+--version 1.17 \
 --tags cluster-type=workshop,department=dev \
 --region "${AWS_REGION}" \
 --zones "${AZS[0]},${AZS[1]},${AZS[2]}" \
@@ -123,7 +123,7 @@ We can also generate cluster configuration file using cli by using `--dry-run` f
 ```bash
 eksctl create cluster \
 --name eksworkshop-eksctl \
---version 1.19 \
+--version 1.17 \
 --tags cluster-type=workshop,department=dev \
 --region "${AWS_REGION}" \
 --zones "${AZS[0]},${AZS[1]},${AZS[2]}" \

--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -53,6 +53,9 @@ metadata:
   name: eksworkshop-eksctl
   region: ${AWS_REGION}
   version: "1.19"
+  tags:
+    cluster-type: workshop
+    department: dev
 
 availabilityZones: ["${AZS[0]}", "${AZS[1]}", "${AZS[2]}"]
 
@@ -95,8 +98,7 @@ eksctl create cluster \
 --region "${AWS_REGION}" \
 --zones "${AZS[0]},${AZS[1]},${AZS[2]}" \
 --nodes 3 \
---node-type t3.medium \
---node-private-networking \
+--node-type t3.small \
 --enable-ssm \
 --managed
 ```
@@ -126,8 +128,7 @@ eksctl create cluster \
 --region "${AWS_REGION}" \
 --zones "${AZS[0]},${AZS[1]},${AZS[2]}" \
 --nodes 3 \
---node-type t3.medium \
---node-private-networking \
+--node-type t3.small \
 --enable-ssm \
 --managed \
 --dry-run

--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -61,3 +61,15 @@ We are deliberatly launching one version behind the latest (1.19 vs. 1.20) to al
 {{% notice info %}}
 Launching EKS and all the dependencies will take approximately 15 minutes
 {{% /notice %}}
+
+Kubernetes secrets are just base64 encoded strings. It is highly recommended to encrypt secrets using trusted and secure encryption service. 
+Next, we will enable kubernetes secrets encryption using AWS KMS. It will also encrypt existing secrets in cluster.
+ 
+```bash
+eksctl utils enable-secrets-encryption \
+--region "${AWS_REGION}" \
+--cluster eksworkshop-eksctl \
+--encrypt-existing-secrets \
+--key-arn "${MASTER_ARN}" \
+--approve
+```

--- a/content/030_eksctl/prerequisites.md
+++ b/content/030_eksctl/prerequisites.md
@@ -6,10 +6,12 @@ weight: 10
 
 For this module, we need to download the [eksctl](https://eksctl.io/) binary:
 
+#### Install eksctl
 ```bash
-curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/0.44.0/eksctl_Linux_amd64.tar.gz" | tar xz -C /tmp
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 
-sudo mv -v /tmp/eksctl /usr/local/bin
+sudo mv /tmp/eksctl /usr/local/bin
+sudo chmod +x /usr/local/bin/eksctl
 ```
 
 Confirm the eksctl command works:


### PR DESCRIPTION
*Issue #, if available:*
Currently in workshop, eksctl is being created via configuration file, which is bit counter intuit. Update material to use `eksctl` cli directly instead of configuration file along with tagging support.

*Description of changes:*
update pre-requisites to use eksctl version 0.48 or higher
launch cluster via eksctl cli
add support for tagging cluster nodes, instances and ebs volumes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
