### PR TITLE
Update codepipeline and flux labs

### DIFF
--- a/templates/ci-cd-codepipeline.cfn.yml
+++ b/templates/ci-cd-codepipeline.cfn.yml
@@ -48,8 +48,8 @@ Parameters:
 
   CodeBuildDockerImage:
     Type: String
-    Default: aws/codebuild/docker:17.09.0
-    Description: Default AWS CodeBuild Docker optimized image
+    Default: aws/codebuild/standard:4.0
+    Description: Default AWS CodeBuild image for Ubuntu 18.04
     MinLength: 3
     MaxLength: 100
     ConstraintDescription: You must enter a CodeBuild Docker image
@@ -221,6 +221,7 @@ Resources:
         ComputeType: BUILD_GENERAL1_SMALL
         Type: LINUX_CONTAINER
         Image: !Ref CodeBuildDockerImage
+        PrivilegedMode: true
         EnvironmentVariables:
           - Name: REPOSITORY_URI
             Value: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrDockerRepository}

--- a/templates/weave_flux_pipeline.cfn.yml
+++ b/templates/weave_flux_pipeline.cfn.yml
@@ -161,6 +161,7 @@ Resources:
               runtime-versions:
                 docker: 18
               commands:
+                - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
                 - apt-get -y update
                 - apt-get -y install jq
             pre_build:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Points default docker image to Ubuntu 18.04 - The docker image aws/codebuild/docker:17.09.0 is no longer supported and also results in a build error when launching the template.
* Adds `PrivilegedMode: true` which is a requirement for Docker image builds per the [docs](https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker.html).
* Updates yarnpk gpg key - See https://github.com/yarnpkg/yarn/issues/7866

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
