### PR TITLE
Update map_iam_user_to_k8s_user.md

### DIFF
--- a/content/beginner/090_rbac/map_iam_user_to_k8s_user.md
+++ b/content/beginner/090_rbac/map_iam_user_to_k8s_user.md
@@ -7,7 +7,7 @@ weight: 30
 
 Next, we'll define a k8s user called rbac-user, and map to its IAM user counterpart.  Run the following to get the existing ConfigMap and save into a file called aws-auth.yaml:
 ```
-kubectl get configmap -n kube-system aws-auth -o yaml > aws-auth.yaml
+kubectl get configmap -n kube-system aws-auth -o yaml | grep -v "creationTimestamp\|resourceVersion\|selfLink\|uid" | sed '/^  annotations:/,+2 d' > aws-auth.yaml
 ```
 Next append the rbac-user mapping to the existing configMap
 


### PR DESCRIPTION
Updated `kubectl get configmap` command to remove metadata that causes problems if you try and run the `kubectl apply` command multiple times, and during the clean-up step at the end of the module. This updated command strips out all the irrelevant metadata and leaves just the `name` and `namespace` metadata parameters.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
