### PR TITLE
Update update_application.md for deployment.yaml path missing on page

### DIFF
--- a/content/intermediate/290_argocd/update_application.md
+++ b/content/intermediate/290_argocd/update_application.md
@@ -7,12 +7,9 @@ draft: false
 Our application is now deployed into our ArgoCD. We are now going to update our github repository synced with our application
 
 ### Update your application
-<div data-proofer-ignore>
-Go to your Github fork repository (replace GITHUB_USERNAME with your own):
-https://github.com/GITHUB_USERNAME/ecsdemo-nodejs/blob/master/kubernetes/deployment.yaml
-</div>
+Go to your Github fork repository:
 
-Update `spec.replicas: 2`
+Update `spec.replicas: 2` in `ecsdemo-nodejs/kubernetes/deployment.yaml`
 ```
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Updated the "deployment.yaml" path in documentation. This was not displaying that may causes problem to readers to follow the steps.
 
*Issue #, if available:*to 

*Description of changes:*
I have updated the file-path instead of url-path for "ecsdemo-nodejs/kubernetes/deployment.yaml"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
