### PR TITLE
Fix link to c9 resize anchor

### DIFF
--- a/content/advanced/330_servicemesh_using_appmesh/add_nodegroup_fargate/_index.md
+++ b/content/advanced/330_servicemesh_using_appmesh/add_nodegroup_fargate/_index.md
@@ -16,7 +16,7 @@ In this chapter, we will perform the following tasks in your existing EKS cluste
 
 * We assume that we have an existing EKS Cluster `eksworkshop-eksctl` created from [EKS Workshop](/030_eksctl/launcheks/).
 
-* We also assume that we have [increased the disk size on your Cloud9 instance](020_prerequisites/workspace/#increase-the-disk-size-on-the-cloud9-instance) as we need to build docker images for our application.
+* We also assume that we have [increased the disk size on your Cloud9 instance](/020_prerequisites/workspace/#increase-the-disk-size-on-the-cloud9-instance) as we need to build docker images for our application.
 
 * We will be using AWS Console to navigate and explore resources in Amazon EKS, AWS App Mesh, Amazon Cloudwatch, AWS X-Ray in this workshop. 
 So ensure that you have completed [Console Credentials](/030_eksctl/console/) to get full access to your existing EKS Cluster `eksworkshop-eksctl` in the EKS console.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the rendered link yield https://www.eksworkshop.com/advanced/330_servicemesh_using_appmesh/add_nodegroup_fargate/020_prerequisites/workspace/#increase-the-disk-size-on-the-cloud9-instance, which is wrong. Prepending / should fix this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
