### PR TITLE
Update 90_cleanup.md - Unset role on both nodegroups

### DIFF
--- a/content/beginner/115_sg-per-pod/90_cleanup.md
+++ b/content/beginner/115_sg-per-pod/90_cleanup.md
@@ -46,10 +46,19 @@ kubectl delete ns sg-per-pod
 kubectl -n kube-system set env daemonset aws-node ENABLE_POD_ENI=false
 kubectl -n kube-system rollout status ds aws-node
 
-# detach the IAM policy
+# detach the IAM policy, first nodegroup
+stack_role=$(aws cloudformation describe-stack-resources --stack-name eksctl-eksworkshop-eksctl-nodegroup-nodegroup | jq -r '.StackResources[] | select(.ResourceType=="AWS::IAM::Role") | .PhysicalResourceId')
+
 aws iam detach-role-policy \
     --policy-arn arn:aws:iam::aws:policy/AmazonEKSVPCResourceController \
-    --role-name ${ROLE_NAME}
+    --role-name $stack_role
+
+# detach the IAM policy, second nodegroup
+stack_role=$(aws cloudformation describe-stack-resources --stack-name eksctl-eksworkshop-eksctl-nodegroup-nodegroup-sec-group | jq -r '.StackResources[] | select(.ResourceType=="AWS::IAM::Role") | .PhysicalResourceId')
+
+aws iam detach-role-policy \
+    --policy-arn arn:aws:iam::aws:policy/AmazonEKSVPCResourceController \
+    --role-name $stack_role
 
 # remove the security groups rules
 aws ec2 revoke-security-group-ingress \


### PR DESCRIPTION
*Issue #, if available:*

IAM role AmazonEKSVPCResourceController being detached only from primary nodegroup

*Description of changes:*

At this step we have two nodegroups, hence two roles, detach AmazonEKSVPCResourceController from both

Alt option (obviously hard to understand and less readable)

```bash
for stack_name in $(eksctl get nodegroup --cluster eksworkshop-eksctl -o json | jq -r '.[].StackName'); do
   stack_role=$(aws cloudformation describe-stack-resources --stack-name $stack_name | jq -r '.StackResources[] | select(.ResourceType=="AWS::IAM::Role") | .PhysicalResourceId')
   aws iam detach-role-policy \
     --policy-arn arn:aws:iam::aws:policy/AmazonEKSVPCResourceController \
     --role-name $stack_role
done
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
