### PR TITLE
Update configure-cni.md

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/configure-cni.md
@@ -49,7 +49,7 @@ Use caution before you run the next command because it terminates all worker nod
 {{% /notice %}}
 
 ```
-INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text` )
+INSTANCE_IDS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text`
 for i in "${INSTANCE_IDS[@]}"
 do
 	echo "Terminating EC2 instance $i ..."


### PR DESCRIPTION
This step is not correct:

INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text`)

Here  INSTANCE_IDS contain one EC2 instance Id, which is not desired behavior.

But it should be:

INSTANCE_IDS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text`

now INSTANCE_IDS contain multiple EC2 instance Ids.

*Issue #, if available:*
#1165 
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
