### PR TITLE
Update eniconfig_crd.md

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/eniconfig_crd.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/eniconfig_crd.md
@@ -49,7 +49,10 @@ aws ec2 describe-subnets  --filters "Name=cidr-block,Values=100.64.*" --query 'S
 {{< /output >}}
 Check your Worker Node SecurityGroup
 ```
-INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text`)
+INSTANCE_IDS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=instance-state-name,Values=running" "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*"  --output text`!
+![EKS Woekshop Issue-b](https://user-images.githubusercontent.com/37997251/120508853-b108c080-c3e5-11eb-980c-59d199fcb403.JPG)
+![EKS Workshop Issue-a](https://user-images.githubusercontent.com/37997251/120508859-b2d28400-c3e5-11eb-881a-5766b36f9692.JPG)
+![EKS Workshop Issue solution](https://user-images.githubusercontent.com/37997251/120508865-b36b1a80-c3e5-11eb-8060-b492c18d5360.JPG)
 for i in "${INSTANCE_IDS[@]}"
 do
   echo "SecurityGroup for EC2 instance $i ..."


### PR DESCRIPTION
There are two issues with below command:

INSTANCE_IDS=(`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text`)

One is that this will only store one value in INSTANCE_IDS shell variable which is not intention here. So right command should be:

INSTANCE_IDS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*" --output text`

For more details please see pull request #1166 and issue#1165

The second issue is that it fetches all instance ids be it running or terminated with the defined tags, in last page of this workshop: Configure CNI page:

//Terminate worker nodes so that Autoscaling launches newer nodes that come bootstrapped with custom network config

it will also pick up terminated worker nodes for sometime which is not intended.

Please see attached screenshots for details.

So the right command should be (tested fine) which will only pick running instances.

INSTANCE_IDS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].InstanceId' --filters "Name=instance-state-name,Values=running" "Name=tag-key,Values=eks:cluster-name" "Name=tag-value,Values=eksworkshop*"  --output text`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
