### PR TITLE
Deprecate 'kubectl run' for deployment creation

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/test_networking.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/test_networking.md
@@ -8,7 +8,7 @@ weight: 50
 
 Let's launch few pods and test networking
 ```
-kubectl run nginx --image=nginx
+kubectl create deployment nginx --image=nginx
 kubectl scale --replicas=3 deployments/nginx
 kubectl expose deployment/nginx --type=NodePort --port 80
 kubectl get pods -o wide


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1158
*Description of changes:*
Updates deprecated `kubectl run` for creating deployments. This currently only results in a warning but will break in later kubectl versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
