### PR TITLE
Calico Enterprise deployment failing due to pods limitation

### DIFF
--- a/content/beginner/120_network-policies/calico-enterprise/register.md
+++ b/content/beginner/120_network-policies/calico-enterprise/register.md
@@ -22,6 +22,8 @@ The team at Tigera offers a free access to [Calico Enterprise Edition](https://w
 
 - You may follow the instructions provided in the email to register your EKS cluster and go through the advanced labs!
 
+- You may need to change the EKS node-group instance types from `t3.small` to `t3.medium` to be able to successfully complete Calico Enterprise deployment (each instance type has limitations on how many pods can be created, that is why `t3.small` may not be able to accommodate required number of pods)
+
 
 ```
 🐯 → curl -s https://tigera-installer.storage.googleapis.com/XXXXXXXX--management_install.sh | bash


### PR DESCRIPTION
*Issue #, if available:*

I wasn't able to complete Calico Enterprise deployment using the default `eksworkshop.yaml` configuration from here https://github.com/aws-samples/eks-workshop/blob/main/content/030_eksctl/launcheks.md

t3.small type can have only 11 pods per https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt

```
$ kubectl get DaemonSet/compliance-benchmarker -n tigera-compliance
NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
compliance-benchmarker   3         3         2       3            2           kubernetes.io/os=linux   29m
```

```
  Type     Reason            Age                 From               Message
  ----     ------            ----                ----               -------
  Warning  FailedScheduling  31m (x3 over 31m)   default-scheduler  0/3 nodes are available: 1 Insufficient pods, 2 node(s) didn't match node selector.
  Warning  FailedScheduling  43s (x23 over 30m)  default-scheduler  0/3 nodes are available: 1 node(s) didn't match node selector, 2 Insufficient pods.
```

*Description of changes:*

Add a note

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
