### PR TITLE
update istio version to 1.10.0

### DIFF
--- a/content/advanced/310_servicemesh_with_istio/download.md
+++ b/content/advanced/310_servicemesh_with_istio/download.md
@@ -8,17 +8,17 @@ draft: false
 Before we can get started configuring Istio we’ll need to first install the command line tools that you will interact with. To do this run the following.
 
 {{% notice info %}}
-We will use istio version `1.9.0`
+We will use istio version `1.10.0`
 {{% /notice %}}
 
 ```bash
-echo 'export ISTIO_VERSION="1.9.0"' >> ${HOME}/.bash_profile
+echo 'export ISTIO_VERSION="1.10.0"' >> ${HOME}/.bash_profile
 source ${HOME}/.bash_profile
 ```
 
 ```bash
 cd ~/environment
-curl -L https://istio.io/downloadIstio | sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
 ```
 
 The installation directory contains:

--- a/content/advanced/310_servicemesh_with_istio/install.md
+++ b/content/advanced/310_servicemesh_with_istio/install.md
@@ -15,7 +15,7 @@ For more information about Istio profile, [click here](https://istio.io/docs/set
 Istio will be installed in the `istio-system` namespace.
 
 ```bash
-yes | istioctl manifest apply --set profile=demo
+yes | istioctl install --set profile=demo
 ```
 
 {{< output >}}


### PR DESCRIPTION
*Issue #, if available:*
currently workshop material is using istio version 1.9.0

*Description of changes:*
- update content to use istio version 1.10.0
- replace `istioctl manifest apply` with `istioctl install` in istio installation section

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
