### PR TITLE
Bugfix: replace old version of istio on introduction.md

### DIFF
--- a/content/advanced/310_servicemesh_with_istio/download.md
+++ b/content/advanced/310_servicemesh_with_istio/download.md
@@ -8,17 +8,17 @@ draft: false
 Before we can get started configuring Istio we’ll need to first install the command line tools that you will interact with. To do this run the following.
 
 {{% notice info %}}
-We will use istio version `1.9.0`
+We will use istio version `1.10.0`
 {{% /notice %}}
 
 ```bash
-echo 'export ISTIO_VERSION="1.9.0"' >> ${HOME}/.bash_profile
+echo 'export ISTIO_VERSION="1.10.0"' >> ${HOME}/.bash_profile
 source ${HOME}/.bash_profile
 ```
 
 ```bash
 cd ~/environment
-curl -L https://istio.io/downloadIstio | sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
 ```
 
 The installation directory contains:

--- a/content/advanced/310_servicemesh_with_istio/install.md
+++ b/content/advanced/310_servicemesh_with_istio/install.md
@@ -15,7 +15,7 @@ For more information about Istio profile, [click here](https://istio.io/docs/set
 Istio will be installed in the `istio-system` namespace.
 
 ```bash
-yes | istioctl manifest apply --set profile=demo
+yes | istioctl install --set profile=demo
 ```
 
 {{< output >}}

--- a/content/advanced/310_servicemesh_with_istio/introduction.md
+++ b/content/advanced/310_servicemesh_with_istio/introduction.md
@@ -6,8 +6,8 @@ draft: false
 ---
 
 {{% notice info %}}
-This chapter has been updated to Istio 1.9.x.
-[Click here](https://istio.io/latest/news/releases/1.9.x/) to know more about this new release.
+This chapter has been updated to Istio 1.10.x
+[Click here](https://istio.io/latest/news/releases/1.10.x/) to know more about this new release.
 {{% /notice %}}
 
 Istio is a completely open source service mesh that layers transparently onto existing distributed applications. It's also a platform, including APIs, that let it integrate into any logging platform, or telemetry or policy system.


### PR DESCRIPTION
*Issue #, if available:*
introduction.md was still showing istio version 1.9.x in advanced->service mesh with istio-> introduction

*Description of changes:*
updated page to reflect istio version 1.10.x

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
@Jukie 