### PR TITLE
Update Ingress Controller lab to support latest sample application

### DIFF
--- a/content/beginner/130_exposing-service/cleaning.md
+++ b/content/beginner/130_exposing-service/cleaning.md
@@ -22,7 +22,7 @@ if [ "`echo "${EKS_CLUSTER_VERSION} < 1.19" | bc`" -eq 1 ]; then
     | kubectl delete -f -
 fi
 
-if [ "`echo "${EKS_CLUSTER_VERSION} > 1.19" | bc`" -eq 1 ]; then     
+if [ "`echo "${EKS_CLUSTER_VERSION} >= 1.19" | bc`" -eq 1 ]; then     
     curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full_latest.yaml \
     | sed 's=alb.ingress.kubernetes.io/target-type: ip=alb.ingress.kubernetes.io/target-type: instance=g' \
     | kubectl delete -f -

--- a/content/beginner/130_exposing-service/cleaning.md
+++ b/content/beginner/130_exposing-service/cleaning.md
@@ -14,9 +14,21 @@ kubectl delete -f ~/environment/run-my-nginx.yaml
 kubectl delete ns my-nginx
 rm ~/environment/run-my-nginx.yaml
 
-curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full.yaml \
+export EKS_CLUSTER_VERSION=$(aws eks describe-cluster --name eksworkshop-eksctl --query cluster.version --output text)
+
+if [ "`echo "${EKS_CLUSTER_VERSION} < 1.19" | bc`" -eq 1 ]; then     
+    curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full.yaml \
     | sed 's=alb.ingress.kubernetes.io/target-type: ip=alb.ingress.kubernetes.io/target-type: instance=g' \
     | kubectl delete -f -
+fi
+
+if [ "`echo "${EKS_CLUSTER_VERSION} > 1.19" | bc`" -eq 1 ]; then     
+    curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full_latest.yaml \
+    | sed 's=alb.ingress.kubernetes.io/target-type: ip=alb.ingress.kubernetes.io/target-type: instance=g' \
+    | kubectl delete -f -
+fi
+
+unset EKS_CLUSTER_VERSION
 
 helm uninstall aws-load-balancer-controller \
     -n kube-system

--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -141,7 +141,7 @@ if [ "`echo "${EKS_CLUSTER_VERSION} < 1.19" | bc`" -eq 1 ]; then
     | kubectl apply -f -
 fi
 
-if [ "`echo "${EKS_CLUSTER_VERSION} > 1.19" | bc`" -eq 1 ]; then     
+if [ "`echo "${EKS_CLUSTER_VERSION} >= 1.19" | bc`" -eq 1 ]; then     
     curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full_latest.yaml \
     | sed 's=alb.ingress.kubernetes.io/target-type: ip=alb.ingress.kubernetes.io/target-type: instance=g' \
     | kubectl apply -f -

--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -133,9 +133,19 @@ Now let’s deploy a sample [2048 game](https://gabrielecirulli.github.io/2048/)
 Deploy 2048 game resources:
 
 ```bash
-curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full.yaml \
+export EKS_CLUSTER_VERSION=$(aws eks describe-cluster --name eksworkshop-eksctl --query cluster.version --output text)
+
+if [ "`echo "${EKS_CLUSTER_VERSION} < 1.19" | bc`" -eq 1 ]; then     
+    curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full.yaml \
     | sed 's=alb.ingress.kubernetes.io/target-type: ip=alb.ingress.kubernetes.io/target-type: instance=g' \
     | kubectl apply -f -
+fi
+
+if [ "`echo "${EKS_CLUSTER_VERSION} > 1.19" | bc`" -eq 1 ]; then     
+    curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full_latest.yaml \
+    | sed 's=alb.ingress.kubernetes.io/target-type: ip=alb.ingress.kubernetes.io/target-type: instance=g' \
+    | kubectl apply -f -
+fi
 ```
 
 After few seconds, verify that the Ingress resource is enabled:


### PR DESCRIPTION
The `Beginner > Exposing a Service > Ingress Controller` sample application does not support Kubernetes Versions 1.19+.    I worked with the kubernetes-sig/aws-load-balancer-controller maintainers to [revert a change](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2068) that broke the lab.

In addition, I created a [PR with the kubernetes-sig/aws-load-balancer-controller maintainers](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2072) to added support for the new spec in the Ingress resource in Kubernetes version 1.19.

This PR is to update the lab to support the PR in kubernetes-sig/aws-load-balancer-controller.

Tested with this PR with the following Kubernetes Versions:
- [x] 1.17
- [x] 1.18
- [x] 1.19
- [x] 1.20

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
