### PR TITLE
jenkins-deploy-workshop: updated jenkins version and plugin versions which are compatible with each other

### DIFF
--- a/content/intermediate/210_jenkins/deploy.md
+++ b/content/intermediate/210_jenkins/deploy.md
@@ -12,9 +12,26 @@ We'll begin by creating the `values.yaml` to declare the configuration of our Je
 ```bash
 cat << EOF > values.yaml
 ---
-master:
+controller:
+  # Used for label app.kubernetes.io/component
+  componentName: "jenkins-controller"
+  image: "jenkins/jenkins"
+  tag: "2.289.2-lts-jdk11"
   additionalPlugins:
     - aws-codecommit-jobs:0.3.0
+    - aws-java-sdk:1.11.995
+    - junit:1.51
+    - ace-editor:1.1
+    - workflow-support:3.8
+    - pipeline-model-api:1.8.5
+    - pipeline-model-definition:1.8.5
+    - pipeline-model-extensions:1.8.5
+    - workflow-job:2.41
+    - credentials-binding:1.26
+    - aws-credentials:1.29
+    - credentials:2.5
+    - lockable-resources:2.11
+    - branch-api:2.6.4
   resources:
     requests:
       cpu: "1024m"


### PR DESCRIPTION


*Issue #, if available:* https://github.com/aws-samples/eks-workshop/issues/991

*Description of changes:* 
Added compatible Jenkins plugin versions as codecommit jobs plugin is currently in broken state.
Set Jenkins image tag to current latest lts tag


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
