### PR TITLE
fix LimitExceeded error on multiple script runs

### DIFF
--- a/content/intermediate/246_monitoring_amp_amg/setup_iam.md
+++ b/content/intermediate/246_monitoring_amp_amg/setup_iam.md
@@ -63,7 +63,7 @@ EOF
 # Get the old trust policy, if one exists, and append it to the new trust policy
 #
 OLD_TRUST_RELATIONSHIP=$(aws iam get-role --role-name $SERVICE_ACCOUNT_IAM_ROLE --query 'Role.AssumeRolePolicyDocument.Statement[]' --output json)
-COMBINED_TRUST_RELATIONSHIP=$(echo $OLD_TRUST_RELATIONSHIP $NEW_TRUST_RELATIONSHIP | jq -s add)
+COMBINED_TRUST_RELATIONSHIP=$(echo $OLD_TRUST_RELATIONSHIP $NEW_TRUST_RELATIONSHIP | jq -s add | jq '. | unique')
 echo "Appending to the existing trust policy"
 read -r -d '' TRUST_POLICY <<EOF
 {


### PR DESCRIPTION
When running the script more several times, the size of the AssumeRolePolicyDocument can reach the 2048 characters limit.
Adding a `unique` function to `jq` will allow running the script multiple times without increasing the role trust policy size.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
