### PR TITLE
Fix the Hyperlink Reference to IAM Roles for Service Accounts

### DIFF
--- a/content/intermediate/210_jenkins/_index.md
+++ b/content/intermediate/210_jenkins/_index.md
@@ -11,4 +11,4 @@ tags:
 
 # Deploy Jenkins
 
-In this Chapter, we will deploy Jenkins using the [Helm](https://helm.sh/) package manager we installed in the [Helm module]({{< ref "beginner/060_helm">}}) and the OIDC identity provider we setup in the [IAM Roles for Service Accounts module]({{ ref "beginner/110_irsa"}}).
+In this Chapter, we will deploy Jenkins using the [Helm](https://helm.sh/) package manager we installed in the [Helm module]({{< ref "beginner/060_helm">}}) and the OIDC identity provider we setup in the [IAM Roles for Service Accounts module]({{< ref "beginner/110_irsa">}}).


### PR DESCRIPTION
*Description of changes:*

The hyperlink to this IAM Roles in this page is broken - https://www.eksworkshop.com/intermediate/210_jenkins/
The markdown change fixes the broken hyperlink.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
