### PR TITLE
Moving the frontend repo clone from brentley to aws-containers repo

### DIFF
--- a/content/020_prerequisites/clone.md
+++ b/content/020_prerequisites/clone.md
@@ -6,7 +6,7 @@ weight: 23
 
 ```
 cd ~/environment
-git clone https://github.com/brentley/ecsdemo-frontend.git
+git clone https://github.com/aws-containers/ecsdemo-frontend.git
 git clone https://github.com/brentley/ecsdemo-nodejs.git
 git clone https://github.com/brentley/ecsdemo-crystal.git
 ```


### PR DESCRIPTION
*Description of changes:*
Migrating ecsdemo-frontend repo to aws-containers org.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
