### PR TITLE
Bug 🐛  - Fixing missing tag on subnet for EFS module

### DIFF
--- a/content/beginner/190_efs/launching-efs.md
+++ b/content/beginner/190_efs/launching-efs.md
@@ -36,9 +36,9 @@ The EKS cluster that you created comprises worker nodes that are resident in the
 
 The following set of commands identifies the public subnets in your cluster VPC and creates a mount target in each one of them as well as associate that mount target with the security group you created above.
 ```
-TAG1=tag:kubernetes.io/cluster/$CLUSTER_NAME
+TAG1=tag:alpha.eksctl.io/cluster-name
 TAG2=tag:kubernetes.io/role/elb
-subnets=($(aws ec2 describe-subnets --filters "Name=$TAG1,Values=shared" "Name=$TAG2,Values=1" | jq --raw-output '.Subnets[].SubnetId'))
+subnets=($(aws ec2 describe-subnets --filters "Name=$TAG1,Values=$CLUSTER_NAME" "Name=$TAG2,Values=1" | jq --raw-output '.Subnets[].SubnetId'))
 for subnet in ${subnets[@]}
 do
     echo "creating mount target in " $subnet


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Starting with 1.19, Amazon EKS no longer adds the kubernetes.io/cluster/<cluster-name> tag to subnets passed in during cluster creation ([official documentation](https://docs.amazonaws.cn/en_us/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.19)). 

Currently the EFS module in the EKS workshop is broken because when it's trying to find all the public subnets that should be used to create the EFS mount-target, it's trying to do a `aws ec2 describe-subnets --filter <TAGS>` where the `kubernetes.io/cluster/$CLUSTER_NAME` it not anymore available on EKS versions 1.19 and above. 

For a fix, I'm suggesting using the `alpha.eksctl.io/cluster-name` with value `$CLUSTER_NAME` to fix the issue.

I have tested and validated that this works on versions 1.19+, which is the version the EKS workshop is using.

Thank you! 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
