### PR TITLE
Updated Lab 115 - Pod Security Groups

### DIFF
--- a/content/beginner/115_sg-per-pod/09_prerequisite.md
+++ b/content/beginner/115_sg-per-pod/09_prerequisite.md
@@ -28,7 +28,7 @@ EoF
 eksctl create nodegroup -f ${HOME}/environment/sg-per-pod/nodegroup-sec-group.yaml
 
  kubectl get nodes \
-  --selector beta.kubernetes.io/instance-type=m5.large
+  --selector node.kubernetes.io/instance-type=m5.large
 ```
 
 {{< output >}}

--- a/content/beginner/115_sg-per-pod/10_secgroup.md
+++ b/content/beginner/115_sg-per-pod/10_secgroup.md
@@ -75,7 +75,7 @@ aws ec2 authorize-security-group-ingress \
 Finally, we will add two inbound traffic (ingress) [rules](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#SecurityGroupRules) to the RDS_SG security group:
 
 * One for Cloud9 (to populate the database).
-* And a second one to allow POD_SG security group to connect to the database.
+* One to allow POD_SG security group to connect to the database.
 
 ```bash
 # Cloud9 IP

--- a/content/beginner/115_sg-per-pod/20_rds.md
+++ b/content/beginner/115_sg-per-pod/20_rds.md
@@ -86,7 +86,7 @@ echo "RDS endpoint: ${RDS_ENDPOINT}"
 Our last step is to create some content in the database.
 
 ```bash
-sudo yum install -y postgresql
+sudo amazon-linux-extras install -y postgresql12
 
 cd sg-per-pod
 

--- a/content/beginner/115_sg-per-pod/30_cni_config.md
+++ b/content/beginner/115_sg-per-pod/30_cni_config.md
@@ -37,7 +37,7 @@ Once this setting is set to true, for each node in the cluster the plugin adds a
 
 ```bash
  kubectl get nodes \
-  --selector alpha.eksctl.io/nodegroup-name=nodegroup-sec-group \
+  --selector  eks.amazonaws.com/nodegroup=nodegroup-sec-group \
   --show-labels
 ```
 

--- a/content/beginner/115_sg-per-pod/50_deploy.md
+++ b/content/beginner/115_sg-per-pod/50_deploy.md
@@ -84,10 +84,10 @@ kubectl -n sg-per-pod  logs -f ${GREEN_POD_NAME}
 
 Output
 
-{{% output %}}
+{{< output >}}
 [('--------------------------',), ('Welcome to the eksworkshop',), ('--------------------------',)]
 [('--------------------------',), ('Welcome to the eksworkshop',), ('--------------------------',)]
-{{% /output %}}
+{{< /output >}}
 
 {{% notice note %}}
 use _CTRL+C_ to exit the log
@@ -155,7 +155,7 @@ Output
 Database connection failed due to timeout expired
 {{< /output >}}
 
-Finally let's verify that the pod doesn't have an _enitId_ `annotation`.
+Finally let's verify that the pod doesn't have an _eniId_ `annotation`.
 
 ```bash
 kubectl -n sg-per-pod  describe pod ${RED_POD_NAME} | head -11

--- a/content/beginner/115_sg-per-pod/90_cleanup.md
+++ b/content/beginner/115_sg-per-pod/90_cleanup.md
@@ -25,7 +25,7 @@ export NODE_GROUP_SG=$(aws ec2 describe-security-groups \
     --output text)
 
 # uninstall the RPM package
-sudo yum erase -y postgresql
+sudo yum remove -y $(sudo yum list installed | grep amzn2extra-postgresql12 | awk '{ print $1}')
 
 # delete database
 aws rds delete-db-instance \

--- a/content/beginner/115_sg-per-pod/_index.md
+++ b/content/beginner/115_sg-per-pod/_index.md
@@ -15,7 +15,7 @@ Containerized applications frequently require access to other services running w
 
 On AWS, controlling network level access between services is often accomplished via [security groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html).
 
-Before the release of this new functionality, you could only assign security groups at the node level. And because all nodes inside a Node group share the security group, by allowing the Node group security group to access the RDS instance, all the pods running on theses nodes would have access the database even if only the green pod should have access.
+Before the release of this new functionality, you could only assign security groups at the node level. And because all nodes inside a Node group share the security group, by attaching the security group to access the RDS instance to the Node group, all the pods running on theses nodes would have access the database even if only the green pod should have access.
 
 ![sg-per-pod_1](/images/sg-per-pod/sg-per-pod_1.png)
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Updated Lab 115 - "Security Groups for Pods" - Tested with EKS 1.19, 1.20, and 1.21 all created with eksctl. Docs render correctly via Hugo.

Index: Updated wording for clarity and sentence flow

09_Prerequisites:  Updated node selector as the beta selector was deprecated as of k8s 1.17

10_SecurityGroups: Updated wording for clarity

20_RDS: Updated to PostgreSQL12 via Amazon Linux Extras, the old command installed unsupported version 9.2 and the instance created in above command was Engine V12.

30_CNI: Updated selector from alpha.eksctl to standard eks label provided by managed nodegroups

50_Deploy: Fixed output that was not rendering along with other typo

90_Cleanup: Updated to remove PostgreSQL12 as installed in 20_RDS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
