### PR TITLE
Swapping migrated brentley repos with aws-containers

### DIFF
--- a/content/020_prerequisites/clone.md
+++ b/content/020_prerequisites/clone.md
@@ -7,6 +7,6 @@ weight: 23
 ```
 cd ~/environment
 git clone https://github.com/aws-containers/ecsdemo-frontend.git
-git clone https://github.com/brentley/ecsdemo-nodejs.git
-git clone https://github.com/brentley/ecsdemo-crystal.git
+git clone https://github.com/aws-containers/ecsdemo-nodejs.git
+git clone https://github.com/aws-containers/ecsdemo-crystal.git
 ```

--- a/content/beginner/050_deploy/applications.md
+++ b/content/beginner/050_deploy/applications.md
@@ -28,7 +28,7 @@ spec:
         app: ecsdemo-nodejs
     spec:
       containers:
-      - image: brentley/ecsdemo-nodejs:latest
+      - image: aws-containers/ecsdemo-nodejs:latest
         imagePullPolicy: Always
         name: ecsdemo-nodejs
         ports:

--- a/content/beginner/060_helm/helm_micro/customize.md
+++ b/content/beginner/060_helm/helm_micro/customize.md
@@ -95,10 +95,10 @@ version: 'latest'
 
 # Service Specific Values
 nodejs:
-  image: brentley/ecsdemo-nodejs
+  image: aws-containers/ecsdemo-nodejs
 crystal:
-  image: brentley/ecsdemo-crystal
+  image: aws-containers/ecsdemo-crystal
 frontend:
-  image: brentley/ecsdemo-frontend
+  image: aws-containers/ecsdemo-frontend
 EoF
 ```

--- a/content/beginner/060_helm/helm_micro/rolling_back.md
+++ b/content/beginner/060_helm/helm_micro/rolling_back.md
@@ -8,7 +8,7 @@ Mistakes will happen during deployment, and when they do, Helm makes it easy to 
 
 #### Update the demo application chart with a breaking change
 
-Open **values.yaml** and modify the image name under `nodejs.image` to **brentley/ecsdemo-nodejs-non-existing**. This image does not exist, so this will break our deployment.
+Open **values.yaml** and modify the image name under `nodejs.image` to **aws-containers/ecsdemo-nodejs-non-existing**. This image does not exist, so this will break our deployment.
 
 Deploy the updated demo application chart:
 ```sh

--- a/content/beginner/070_healthchecks/liveness.files/liveness-app.yaml
+++ b/content/beginner/070_healthchecks/liveness.files/liveness-app.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: brentley/ecsdemo-nodejs
+    image: aws-containers/ecsdemo-nodejs
     livenessProbe:
       httpGet:
         path: /health

--- a/content/beginner/070_healthchecks/livenessprobe.md
+++ b/content/beginner/070_healthchecks/livenessprobe.md
@@ -24,7 +24,7 @@ metadata:
 spec:
   containers:
   - name: liveness
-    image: brentley/ecsdemo-nodejs
+    image: aws-containers/ecsdemo-nodejs
     livenessProbe:
       httpGet:
         path: /health
@@ -63,8 +63,8 @@ Events:
   ----    ------                 ----  ----                                    -------
   Normal  Scheduled              38s   default-scheduler                       Successfully assigned liveness-app to ip-192-168-18-63.ec2.internal
   Normal  SuccessfulMountVolume  38s   kubelet, ip-192-168-18-63.ec2.internal  MountVolume.SetUp succeeded for volume "default-token-8bmt2"
-  Normal  Pulling                37s   kubelet, ip-192-168-18-63.ec2.internal  pulling image "brentley/ecsdemo-nodejs"
-  Normal  Pulled                 37s   kubelet, ip-192-168-18-63.ec2.internal  Successfully pulled image "brentley/ecsdemo-nodejs"
+  Normal  Pulling                37s   kubelet, ip-192-168-18-63.ec2.internal  pulling image "aws-containers/ecsdemo-nodejs"
+  Normal  Pulled                 37s   kubelet, ip-192-168-18-63.ec2.internal  Successfully pulled image "aws-containers/ecsdemo-nodejs"
   Normal  Created                37s   kubelet, ip-192-168-18-63.ec2.internal  Created container
   Normal  Started                37s   kubelet, ip-192-168-18-63.ec2.internal  Started container
 {{< /output >}}
@@ -84,8 +84,8 @@ Events:
   Normal   Scheduled              1m                 default-scheduler                       Successfully assigned liveness-app to ip-192-168-18-63.ec2.internal
   Normal   SuccessfulMountVolume  1m                 kubelet, ip-192-168-18-63.ec2.internal  MountVolume.SetUp succeeded for volume "default-token-8bmt2"
   Warning  Unhealthy              30s (x3 over 40s)  kubelet, ip-192-168-18-63.ec2.internal  Liveness probe failed: Get http://192.168.13.176:3000/health: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
-  Normal   Pulling                0s (x2 over 1m)    kubelet, ip-192-168-18-63.ec2.internal  pulling image "brentley/ecsdemo-nodejs"
-  Normal   Pulled                 0s (x2 over 1m)    kubelet, ip-192-168-18-63.ec2.internal  Successfully pulled image "brentley/ecsdemo-nodejs"
+  Normal   Pulling                0s (x2 over 1m)    kubelet, ip-192-168-18-63.ec2.internal  pulling image "aws-containers/ecsdemo-nodejs"
+  Normal   Pulled                 0s (x2 over 1m)    kubelet, ip-192-168-18-63.ec2.internal  Successfully pulled image "aws-containers/ecsdemo-nodejs"
   Normal   Created                0s (x2 over 1m)    kubelet, ip-192-168-18-63.ec2.internal  Created container
   Normal   Started                0s (x2 over 1m)    kubelet, ip-192-168-18-63.ec2.internal  Started container
   Normal   Killing                0s                 kubelet, ip-192-168-18-63.ec2.internal  Killing container with id docker://liveness:Container failed liveness probe.. Container will be killed and recreated.

--- a/content/beginner/150_spotnodegroups/deployapp.files/ecsdemo-crystal-deployment.yml
+++ b/content/beginner/150_spotnodegroups/deployapp.files/ecsdemo-crystal-deployment.yml
@@ -30,7 +30,7 @@ spec:
                 values:
                 - ON_DEMAND
       containers:
-      - image: brentley/ecsdemo-crystal:latest
+      - image: aws-containers/ecsdemo-crystal:latest
         imagePullPolicy: Always
         name: ecsdemo-crystal
         ports:

--- a/content/beginner/150_spotnodegroups/deployapp.files/ecsdemo-frontend-deployment.yml
+++ b/content/beginner/150_spotnodegroups/deployapp.files/ecsdemo-frontend-deployment.yml
@@ -36,7 +36,7 @@ spec:
         value: "true"
         effect: "PreferNoSchedule"
       containers:
-      - image: brentley/ecsdemo-frontend:latest
+      - image: aws-containers/ecsdemo-frontend:latest
         imagePullPolicy: Always
         name: ecsdemo-frontend
         ports:

--- a/content/beginner/150_spotnodegroups/deployapp.files/ecsdemo-nodejs-deployment.yml
+++ b/content/beginner/150_spotnodegroups/deployapp.files/ecsdemo-nodejs-deployment.yml
@@ -30,7 +30,7 @@ spec:
                 values:
                 - ON_DEMAND
       containers:
-      - image: brentley/ecsdemo-nodejs:latest
+      - image: aws-containers/ecsdemo-nodejs:latest
         imagePullPolicy: Always
         name: ecsdemo-nodejs
         ports:

--- a/content/intermediate/290_argocd/deploy_application.md
+++ b/content/intermediate/290_argocd/deploy_application.md
@@ -9,7 +9,7 @@ We now have an ArgoCD fully deployed, we will now deploy an application (ecsdemo
 ### Fork application repository
 First step is to create a fork for the Github application we will deploy.
 
-Login to github, go to: https://github.com/brentley/ecsdemo-nodejs.git and Fork the repo
+Login to github, go to: https://github.com/aws-containers/ecsdemo-nodejs.git and Fork the repo
 ![Fork Img](/images/argocd/fork_app_repo.jpg)
 
 Then into your select the https URL by clicking into button `Clone or download`:

--- a/content/intermediate/290_argocd/update_application.md
+++ b/content/intermediate/290_argocd/update_application.md
@@ -34,7 +34,7 @@ spec:
         app: ecsdemo-nodejs
     spec:
       containers:
-      - image: brentley/ecsdemo-nodejs:latest
+      - image: aws-containers/ecsdemo-nodejs:latest
         imagePullPolicy: Always
         name: ecsdemo-nodejs
         ports:


### PR DESCRIPTION
Migrated the ecsdemo-* apps to aws-containers org.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
