### PR TITLE
Documentation fix - Wrong tag in the "INFO" of the EFS beginner module

### DIFF
--- a/content/beginner/190_efs/launching-efs.md
+++ b/content/beginner/190_efs/launching-efs.md
@@ -48,7 +48,7 @@ done
 
 {{% notice info %}}
 When eksctl provisions your VPC and EKS cluster, it assigns the following tags to all public subnets in the cluster VPC. The above command leverages these tags to identify the public subnets.  
-*kubernetes.io/cluster/eksworkshop-eksctl = shared*  
+*alpha.eksctl.io/cluster-name = eksworkshop-eksctl*  
 *kubernetes.io/role/elb = 1*
 {{% /notice %}}
 


### PR DESCRIPTION
Updating the 'INFO' that was not updated when the fix (https://github.com/aws-samples/eks-workshop/pull/1224) was merged.

*Issue #, if available:*

As part of the PR (https://github.com/aws-samples/eks-workshop/pull/1224) that was merged, we've forgotten to fix the "INFO" section to correct the names of the tags. This PR fixes that to make sure it matches with the right tags we're using on the workshop. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
