### PR TITLE
Updated the load balancer IAM policy installation

### DIFF
--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -83,9 +83,11 @@ Learn more about [IAM Roles for Service Accounts](https://docs.aws.amazon.com/ek
 Create a policy called **AWSLoadBalancerControllerIAMPolicy**
 
 ```bash
+curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
 aws iam create-policy \
     --policy-name AWSLoadBalancerControllerIAMPolicy \
-    --policy-document https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json
+    --policy-document file://iam_policy.json
+rm iam_policy.json
 ```
 
 #### Create a IAM role and ServiceAccount


### PR DESCRIPTION
I updated it based on the documentation (https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html).

I also had to download it locally because I had this error if I did not : 

An error occurred (MalformedPolicyDocument) when calling the CreatePolicy operation: Syntax errors in policy.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
