### PR TITLE
crds remote url fix

### DIFF
--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -103,7 +103,7 @@ eksctl create iamserviceaccount \
 #### Install the TargetGroupBinding CRDs
 
 ```bash
-kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds?ref=master
+kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds
 
 kubectl get crd
 ```


### PR DESCRIPTION
This command did not work on my osx terminal:
```kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds?ref=master``` 

*Description of changes:*
Instead I had to do:
```kubectl apply -k github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds```






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
