### PR TITLE
Update cluster-autoscaler-autodiscover.yaml memory req/limits

### DIFF
--- a/content/beginner/080_scaling/deploy_ca.files/cluster-autoscaler-autodiscover.yaml
+++ b/content/beginner/080_scaling/deploy_ca.files/cluster-autoscaler-autodiscover.yaml
@@ -143,10 +143,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
             requests:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
           command:
             - ./cluster-autoscaler
             - --v=4


### PR DESCRIPTION
Running this example on EKS k8s v1.21 with 300Mi limit makes the process to be OOMKilled at start.
Upstream addressed problem here https://github.com/kubernetes/autoscaler/pull/4207/commits/dcdb9523226ba49f3b0adb23e2adf3a1f95df2a7

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
