### PR TITLE
Removing `ssh: enableSsm: true`

### DIFF
--- a/content/030_eksctl/launcheks.md
+++ b/content/030_eksctl/launcheks.md
@@ -54,8 +54,6 @@ managedNodeGroups:
 - name: nodegroup
   desiredCapacity: 3
   instanceType: t3.small
-  ssh:
-    enableSsm: true
 
 # To enable all of the control plane logs, uncomment below:
 # cloudWatch:


### PR DESCRIPTION
On executing `eksctl create cluster -f eksworkshop.yaml`, a warning message `SSM is now enabled by default; `ssh.enableSSM` is deprecated and will be removed in a future release` appears, and the process fails with an error `panic: runtime error: invalid memory address or nil pointer dereference`. The command succeeds when `ssh: enableSsm: true` is removed from the yaml file.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
