### PR TITLE
Remove "--generator" unnecessary kubectl flag

### DIFF
--- a/content/beginner/080_scaling/test_hpa.md
+++ b/content/beginner/080_scaling/test_hpa.md
@@ -40,7 +40,7 @@ kubectl get hpa
 **Open a new terminal** in the Cloud9 Environment and run the following command to drop into a shell on a new container
 
 ```bash
-kubectl --generator=run-pod/v1 run -i --tty load-generator --image=busybox /bin/sh
+kubectl run -i --tty load-generator --image=busybox /bin/sh
 ```
 
 Execute a while loop to continue getting http:///php-apache


### PR DESCRIPTION
Before k8s v1.18, we use this to create a pod. Now k8s version v1.18+, we don’t need to use this anymore to create a pod.
Simply run the below command to create a pod:

Reference: https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#run

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
