### PR TITLE
Updated file path for install.yaml.

### DIFF
--- a/content/advanced/410_batch/deploy.md
+++ b/content/advanced/410_batch/deploy.md
@@ -13,7 +13,7 @@ Deploy the Controller and UI.
 
 ```bash
 kubectl create namespace argo
-kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/${ARGO_VERSION}/manifests/install.yaml
+kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo-workflows/${ARGO_VERSION}/manifests/install.yaml
 ```
 
 {{< output >}}


### PR DESCRIPTION
https://raw.githubusercontent.com/argoproj/argo/ is more valid. Updated to argo-workflows specific one - https://raw.githubusercontent.com/argoproj/argo-workflows/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
