### PR TITLE
Replace github URL with local file

### DIFF
--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -83,9 +83,11 @@ Learn more about [IAM Roles for Service Accounts](https://docs.aws.amazon.com/ek
 Create a policy called **AWSLoadBalancerControllerIAMPolicy**
 
 ```bash
+wget https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json
+
 aws iam create-policy \
     --policy-name AWSLoadBalancerControllerIAMPolicy \
-    --policy-document https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json
+    --policy-document file://iam_policy.json
 ```
 
 #### Create a IAM role and ServiceAccount


### PR DESCRIPTION
*Issue #, if available:*

The github url for --policy-document param throws a MalformedPolicyDocument exception 

aws iam create-policy \
    --policy-name AWSLoadBalancerControllerIAMPolicy \
    --policy-document https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json 

An error occurred (MalformedPolicyDocument) when calling the CreatePolicy operation: Syntax errors in policy.


*Description of changes:*

Use local file instead 

wget https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json

aws iam create-policy \
     --policy-name AWSLoadBalancerControllerIAMPolicy \
     --policy-document file://iam_policy.json


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
