### PR TITLE
Role and Rolebinding API version bump v1beta1 to v1

### DIFF
--- a/content/beginner/091_iam-groups/create-k8s-rbac.md
+++ b/content/beginner/091_iam-groups/create-k8s-rbac.md
@@ -24,7 +24,7 @@ We create a kubernetes `role` and `rolebinding` in the development namespace giv
 ```bash
 cat << EOF | kubectl apply -f - -n development
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dev-role
 rules:
@@ -57,7 +57,7 @@ rules:
       - "update"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dev-role-binding
 subjects:
@@ -81,7 +81,7 @@ We create a kubernetes `role` and `rolebinding` in the integration namespace for
 ```bash
 cat << EOF | kubectl apply -f - -n integration
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: integ-role
 rules:
@@ -114,7 +114,7 @@ rules:
       - "update"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: integ-role-binding
 subjects:


### PR DESCRIPTION
updating role and rolebinding to k8s API version v1 since v1beta1 will be unavailable in k8s v1.22+

