### PR TITLE
Remove flag --generator when running pod

### DIFF
--- a/content/beginner/130_exposing-service/connecting.md
+++ b/content/beginner/130_exposing-service/connecting.md
@@ -145,7 +145,7 @@ Creating a new deployment called _load-generator_ (with the _MyClusterIP_ variab
 
 ```bash
 # Create a new deployment and allocate a TTY for the container in the pod
-kubectl -n my-nginx run --generator=run-pod/v1 -i --tty load-generator --env="MyClusterIP=${MyClusterIP}" --image=busybox /bin/sh
+kubectl -n my-nginx run -i --tty load-generator --env="MyClusterIP=${MyClusterIP}" --image=busybox /bin/sh
 ```
 
 {{% notice tip %}}


### PR DESCRIPTION
This is no longer needed for v1.18 and above

*Issue #, if available:*

*Description of changes:* Remove flag --generator


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
