### PR TITLE
Update LBC to v2.3.0

### DIFF
--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -66,6 +66,6 @@ kubectl completion bash >>  ~/.bash_completion
 #### set the AWS Load Balancer Controller version
 
 ```bash
-echo 'export LBC_VERSION="v2.2.0"' >>  ~/.bash_profile
+echo 'export LBC_VERSION="v2.3.0"' >>  ~/.bash_profile
 .  ~/.bash_profile
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using helm for installing LBC in the Fargate module (https://www.eksworkshop.com/beginner/180_fargate/prerequisites-for-alb/#deploy-the-helm-chart-from-the-amazon-eks-charts-repo), pods are not running because the helm chart uses latest version of the LBC helm chart, but with specific IMAGE TAG for that helm chart. This cause the use of a flag that doesn't exists in v2.2.0, because it was only introduced in v2.3.0 --> https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases?q=2236&expanded=true --> https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2236 (`disable-restricted-sg-rules` flag)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
