### PR TITLE
modify policy creation command

### DIFF
--- a/content/beginner/180_fargate/prerequisites-for-alb.md
+++ b/content/beginner/180_fargate/prerequisites-for-alb.md
@@ -52,9 +52,10 @@ The next step is to create the IAM policy that will be used by the AWS Load Bala
 This policy will be later associated to the Kubernetes Service Account and will allow the controller pods to create and manage the ELB’s resources in your AWS account for you.
 
 ```bash
+wget https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json
 aws iam create-policy \
     --policy-name AWSLoadBalancerControllerIAMPolicy \
-    --policy-document https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json
+    --policy-document file://iam_policy.json
 ```
 
 #### Create a IAM role and ServiceAccount for the Load Balancer controller


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
AWS CLI V2 doesn't accept HTTP as input for `--policy-document` parameter.
This causes the command to fail

Modifying it to get the IAM policy via `wget` and reference `file://` in the `--policy-document` parameter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
