### PR TITLE
Update basic-pod-limits.md

### DIFF
--- a/content/intermediate/201_resource_management/basic-pod-limits.md
+++ b/content/intermediate/201_resource_management/basic-pod-limits.md
@@ -26,7 +26,7 @@ In order to generate cpu and memory load, we will use [stress-ng](http://manpage
 
 ```sh
 # Deploy request pod with soft limit on memory 
-kubectl run --requests=memory=1G,cpu=0.5 --image  hande007/stress-ng basic-request-pod --restart=Never --  --vm-keep  --vm-bytes 2g --timeout 600s --vm 1 --oomable --verbose 
+kubectl run --requests=memory=1G,cpu=0.5 --image  hande007/stress-ng basic-request-pod --restart=Never --  --vm-keep  --vm-bytes 1.5g --timeout 600s --vm 1 --oomable --verbose 
 
 # Deploy limit-cpu pod with hard limit on cpu at 500m but wants 1000m
 kubectl run --limits=memory=1G,cpu=0.5 --image  hande007/stress-ng basic-limit-cpu-pod --restart=Never --  --vm-keep --vm-bytes 512m --timeout 600s --vm 1 --oomable --verbose 


### PR DESCRIPTION
Under “BASIC POD CPU AND MEMORY MANAGEMENT“ phase, the first pod that our customers need to deploy scales to 2G memory.
“kubectl run --requests=memory=1G,cpu=0.5 --image hande007/stress-ng basic-request-pod --restart=Never -- --vm-keep --vm-bytes 2g --timeout 600s --vm 1 --oomable –verbose”
In the prerequisites of the workshop we provide the customers yaml that build the EKS with t3.small instances which has 2g ram per node. Since that we cannot run 2g memory containers under these nodes as shown in the workshop documentation. I changed the pod to use only 1.5 in order to get the right output

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
