### PR TITLE
removes deprecated `--generator` flag

### DIFF
--- a/content/beginner/080_scaling/test_hpa.md
+++ b/content/beginner/080_scaling/test_hpa.md
@@ -40,7 +40,7 @@ kubectl get hpa
 **Open a new terminal** in the Cloud9 Environment and run the following command to drop into a shell on a new container
 
 ```bash
-kubectl --generator=run-pod/v1 run -i --tty load-generator --image=busybox /bin/sh
+kubectl run -i --tty load-generator --image=busybox /bin/sh
 ```
 
 Execute a while loop to continue getting http:///php-apache

--- a/content/beginner/091_iam-groups/test-cluster-access.md
+++ b/content/beginner/091_iam-groups/test-cluster-access.md
@@ -110,7 +110,7 @@ With this configuration we should be able to interact with the **development** n
 Let's create a pod:
 
 ```bash
-kubectl run --generator=run-pod/v1 nginx-dev --image=nginx -n development
+kubectl run nginx-dev --image=nginx -n development
 ```
 
 We can list the pods:
@@ -146,7 +146,7 @@ cat $KUBECONFIG | yq e '.users.[].user.exec.args += ["--profile", "integ"]' - --
 Let's create a pod:
 
 ```bash
-kubectl run --generator=run-pod/v1 nginx-integ --image=nginx -n integration
+kubectl run nginx-integ --image=nginx -n integration
 ```
 
 We can list the pods:
@@ -182,7 +182,7 @@ cat $KUBECONFIG | yq e '.users.[].user.exec.args += ["--profile", "admin"]' - --
 Let's create a pod in the default namespace:
 
 ```bash
-kubectl run --generator=run-pod/v1 nginx-admin --image=nginx
+kubectl run nginx-admin --image=nginx
 ```
 
 We can list the pods:


### PR DESCRIPTION
removed in https://github.com/kubernetes/kubernetes/pull/87077

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
