### PR TITLE
typo in about_the_k8s_app.md

### DIFF
--- a/content/advanced/330_servicemesh_using_appmesh/deploy_applications/about_the_k8s_app.md
+++ b/content/advanced/330_servicemesh_using_appmesh/deploy_applications/about_the_k8s_app.md
@@ -39,7 +39,7 @@ This application is composed of three microservices:
     }
 }
 {{< /output >}}
-    * Developed in Python Fask Restplus with Swagger UI for Rest API
+    * Developed in Python Flask Restplus with Swagger UI for Rest API
     * Deployed to `EKS Fargate`
 * Catalog Detail Backend
     * Backend service `proddetail` is a Rest API Service that performs following operation:


### PR DESCRIPTION
"Fask" should read "Flask"

*Issue #, if available:* N/A

*Description of changes:*
Corrected spelling of "Flask"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.