### PR TITLE
Updated 'aws-k8s-cni.yaml' to v1.9

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/eniconfig_crd.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/eniconfig_crd.md
@@ -18,7 +18,7 @@ eniconfigs.crd.k8s.amazonaws.com   2021-06-13T14:02:40Z
 {{< /output >}}
 If you don't have ENIConfig installed, you can install it by using this command
 ```
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7/config/v1.7/aws-k8s-cni.yaml
+kubectl apply -f https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.9/aws-k8s-cni.yaml
 ```
 Create custom resources for each subnet by replacing **Subnet** and **SecurityGroup IDs**. Since we created three secondary subnets, we need to create three custom resources.
 


### PR DESCRIPTION
Updated 'aws-k8s-cni.yaml' to v1.9 as v1.7 has deprecated api's

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
