### PR TITLE
Add mandatory flag --cluster for eksctl >= 0.80.0 to write config

### DIFF
--- a/content/beginner/091_iam-groups/test-cluster-access.md
+++ b/content/beginner/091_iam-groups/test-cluster-access.md
@@ -97,7 +97,7 @@ It is also possible to specify the AWS_PROFILE to use with the aws-iam-authentic
 Create a new KUBECONFIG file to test this:
 
 ```bash
-export KUBECONFIG=/tmp/kubeconfig-dev && eksctl utils write-kubeconfig eksworkshop-eksctl
+export KUBECONFIG=/tmp/kubeconfig-dev && eksctl utils write-kubeconfig --cluster=eksworkshop-eksctl
 cat $KUBECONFIG | yq e '.users.[].user.exec.args += ["--profile", "dev"]' - -- | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-dev./g' | sponge $KUBECONFIG
 ```
 
@@ -137,7 +137,7 @@ Error from server (Forbidden): pods is forbidden: User "dev-user" cannot list re
 #### Test with integ profile
 
 ```bash
-export KUBECONFIG=/tmp/kubeconfig-integ && eksctl utils write-kubeconfig eksworkshop-eksctl
+export KUBECONFIG=/tmp/kubeconfig-integ && eksctl utils write-kubeconfig --cluster=eksworkshop-eksctl
 cat $KUBECONFIG | yq e '.users.[].user.exec.args += ["--profile", "integ"]' - -- | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-integ./g' | sponge $KUBECONFIG
 ```
 
@@ -173,7 +173,7 @@ Error from server (Forbidden): pods is forbidden: User "integ-user" cannot list 
 #### Test with admin profile
 
 ```bash
-export KUBECONFIG=/tmp/kubeconfig-admin && eksctl utils write-kubeconfig eksworkshop-eksctl
+export KUBECONFIG=/tmp/kubeconfig-admin && eksctl utils write-kubeconfig --cluster=eksworkshop-eksctl
 cat $KUBECONFIG | yq e '.users.[].user.exec.args += ["--profile", "admin"]' - -- | sed 's/eksworkshop-eksctl./eksworkshop-eksctl-admin./g' | sponge $KUBECONFIG
 ```
 


### PR DESCRIPTION
Starting from eksctl 0.80.0 requires --cluster flag. 

eksctl 0.80.0
Failure: 
eksctl utils write-kubeconfig eksworkshop-eksctl          
Error: --cluster=eksworkshop-eksctl and argument eksworkshop-eksctl cannot be used at the same time

Success: 
eksctl utils write-kubeconfig **--cluster**=eksworkshop-eksctl                                                                                              
2022-01-24 16:51:16 [i]  eksctl version 0.80.0
2022-01-24 16:51:16 [i]  using region eu-west-1
2022-01-24 16:51:16 [✔]  saved kubeconfig as "/tmp/kubeconfig-dev"

*Description of changes:*
With eksctl 0.80.0 , it is require to pass --cluster flag with eksctl utils write-kubeconfig 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
