### PR TITLE
Update instructions with correct URL

### DIFF
--- a/content/beginner/120_network-policies/calico/install_calico.md
+++ b/content/beginner/120_network-policies/calico/install_calico.md
@@ -64,7 +64,7 @@ Here in the Calico manifest, we see tolerations has just one attribute: **Operat
 Watch the kube-system daemon sets and wait for the calico-node daemon set to have the DESIRED number of pods in the READY state.
 
 ```
-kubectl get daemonset calico-node --namespace=kube-system
+kubectl get daemonset calico-node --namespace=calico-system
 ```
 Expected Output:
 

--- a/content/beginner/120_network-policies/calico/install_calico.md
+++ b/content/beginner/120_network-policies/calico/install_calico.md
@@ -8,7 +8,8 @@ Apply the Calico manifest from the [aws/amazon-vpc-cni-k8s GitHub project](https
 
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.6/calico.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/master/calico-operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/master/calico-crs.yaml
 ```
 Let's go over few key features of the Calico manifest:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The URL in the workshop leads to a 404, this adds the correct URL.
Can also update the description to mention the controller being installed, but since the daemonset should still have the same name, everything should still work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
