### PR TITLE
typo: s/Kuberbetes/Kubernetes/

### DIFF
--- a/content/beginner/194_secrets_manager/sync_native_secrets_env.md
+++ b/content/beginner/194_secrets_manager/sync_native_secrets_env.md
@@ -1,5 +1,5 @@
 ---
-title: "Sync with native Kuberbetes secrets"
+title: "Sync with native Kubernetes secrets"
 date: 2021-10-01T00:00:00-04:00
 weight: 40
 draft: false


### PR DESCRIPTION
As great of a name as Kuberbetes is, I thought I'd fix this typo.