### PR TITLE
Change service account for App Mesh injection to default

### DIFF
--- a/content/intermediate/330_app_mesh/port_to_app_mesh/trigger_sidecar_injection.md
+++ b/content/intermediate/330_app_mesh/port_to_app_mesh/trigger_sidecar_injection.md
@@ -21,7 +21,7 @@ aws iam create-policy \
 eksctl create iamserviceaccount \
   --cluster eksworkshop-eksctl \
   --namespace prod \
-  --name prod-proxies \
+  --name default \
   --attach-policy-arn arn:aws:iam::$ACCOUNT_ID:policy/AWSAppMeshEnvoySidecarIAMPolicy  \
   --override-existing-serviceaccounts \
   --approve


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1056

*Description of changes:*

The `prod-proxies` service account was never redeclared onto the deployment, changing the module to set the IAM permissions to the default service account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
