### PR TITLE
Fix for Karpenter pre-requisites related to subnet tagging

### DIFF
--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -9,7 +9,7 @@ Before we install Karpenter, there are a few things that we will need to prepare
 ## Pre-requisites
 
 ```bash
-export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].metadata.name')
+export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].Name')
 export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query Account)
 export AWS_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
 ```


### PR DESCRIPTION
Looks like the json that eksctl outputs has changed in recent version, thus rendering the CLUSTER_NAME env variable as "null" in "Beginner > High-Performance Autoscaling with Karpenter > Set up the environment". This breaks the next step where we try to tag the subnets for Karpenter. The new json format looks like this, thus requiring a small change to the jsonpath used in jq:

$ eksctl get clusters -o json
[
    {
        "Name": "eksworkshop-eksctl",
        "Region": "eu-west-1",
        "Owned": "False"
    }
]

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
