### PR TITLE
docs: update test_hpa.md to drop --generator flag

### DIFF
--- a/content/beginner/080_scaling/test_hpa.md
+++ b/content/beginner/080_scaling/test_hpa.md
@@ -40,7 +40,7 @@ kubectl get hpa
 **Open a new terminal** in the Cloud9 Environment and run the following command to drop into a shell on a new container
 
 ```bash
-kubectl --generator=run-pod/v1 run -i --tty load-generator --image=busybox /bin/sh
+kubectl run -i --tty load-generator --image=busybox /bin/sh
 ```
 
 Execute a while loop to continue getting http:///php-apache


### PR DESCRIPTION
*Issue #, if available:*

--generator flag has been deprecated.

```
~/Workspace/Experiments/eksworkshop ❯ kubectl --generator=run-pod/v1 run -i --tty load-generator --image=busybox /bin/sh                 
                                                                                                                                         
error: unknown flag: --generator
See 'kubectl run --help' for usage.
```

*Description of changes:*
remove generator flag
```
kubectl run -i --tty load-generator --image=busybox /bin/sh    
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
