### PR TITLE
Flux pipeline update

### DIFF
--- a/templates/weave_flux_pipeline.cfn.yml
+++ b/templates/weave_flux_pipeline.cfn.yml
@@ -161,7 +161,9 @@ Resources:
               runtime-versions:
                 docker: 18
               commands:
-                - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+                - sudo mkdir /usr/share/keyrings
+                - KEYRING=/usr/share/keyrings/yarnpkg.gpg
+                - curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo tee "$KEYRING" >/dev/null
                 - apt-get -y update
                 - apt-get -y install jq
             pre_build:


### PR DESCRIPTION
*Issue #, if available:*
#1347

*Description of changes:*
There was a build error during the image build process with the Flux GitOps lab.

This is an alternative to apt-key add as that has been deprecated and was failing the build process for the Flux lab.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
