### PR TITLE
Updating to remove issues with apt-key

### DIFF
--- a/templates/weave_flux_pipeline.cfn.yml
+++ b/templates/weave_flux_pipeline.cfn.yml
@@ -161,7 +161,7 @@ Resources:
               runtime-versions:
                 docker: 18
               commands:
-                - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+                - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
                 - apt-get -y update
                 - apt-get -y install jq
             pre_build:


### PR DESCRIPTION
Removing `sudo` from apt-key line seems to work with the build issue.

*Issue #, if available:*
#1347

*Description of changes:*
`sudo apt-key add -` was failing, removing sudo allows adding of gpg key which removes any build errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
