### PR TITLE
Fix karpenter 404 error

### DIFF
--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -44,7 +44,7 @@ Instances launched by Karpenter must run with an InstanceProfile that grants per
 
 ```bash
 TEMPOUT=$(mktemp)
-curl -fsSL https://karpenter.sh/docs/getting-started/cloudformation.yaml > $TEMPOUT \
+curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-started-with-eksctl/cloudformation.yaml > $TEMPOUT \
 && aws cloudformation deploy \
   --stack-name Karpenter-${CLUSTER_NAME} \
   --template-file ${TEMPOUT} \

--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -9,6 +9,7 @@ Before we install Karpenter, there are a few things that we will need to prepare
 ## Pre-requisites
 
 ```bash
+export KARPENTER_VERSION=v0.7.1
 export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].metadata.name')
 export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query Account)
 export AWS_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')


### PR DESCRIPTION
*Issue #, if available:*
#1358

*Description of changes:*
Modified eks-workshop/content/beginner/085_scaling_karpenter/setup_the_environment.md as follows:

- Added a new environment variable for KARPENTER_VERSION in the Pre-requisites section and created a value of v0.7.1 (current version as of 3/17/2022).
- Changed the curl command for the cloudformation.yaml to include the KARPENTER_VERSION.  This aligns with current url structure on karpenter.sh and the example in https://karpenter.sh/v0.7.1/getting-started/getting-started-with-eksctl/ 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
