### PR TITLE
Update workspace.md

### DIFF
--- a/content/020_prerequisites/workspace.md
+++ b/content/020_prerequisites/workspace.md
@@ -11,7 +11,7 @@ account user.
 {{% /notice %}}
 
 {{% notice warning %}}
-If you are at an AWS Hosted Event Cloud 9 Environment is already built for you. Just open the existing IDE in the Cloud9 console.
+If you are at an AWS Hosted Event the Cloud 9 Environment is already built for you. Just open the existing IDE in the Cloud9 console.
 {{% /notice %}}
 
 {{% notice info %}}

--- a/content/020_prerequisites/workspace.md
+++ b/content/020_prerequisites/workspace.md
@@ -10,6 +10,10 @@ not the root account user. Please ensure you are logged in as an IAM user, not t
 account user.
 {{% /notice %}}
 
+{{% notice warning %}}
+If you are at an AWS Hosted Event Cloud 9 Environment is already built for you. Just open the existing IDE in the Cloud9 console.
+{{% /notice %}}
+
 {{% notice info %}}
 A list of supported browsers for AWS Cloud9 is found [here]( https://docs.aws.amazon.com/cloud9/latest/user-guide/browsers.html).
 {{% /notice %}}


### PR DESCRIPTION
*Issue #, if available:*
For events hosted by AWS the Cloud9 workspace comes by default, which is already mentioned in [at an AWS event](https://www.eksworkshop.com/020_prerequisites/aws_event/portal/) section. However attendees reading the Create a Workspace section gets the idea that they should create a new environment hence they end up creating a second Cloud9 IDE in their space.

*Description of changes:*
Adding a warning message stating that if it is an AWS hosted event the attendees should head over to the Cloud9 environment and open up the existing IDE there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.