### PR TITLE
Updated Info

### DIFF
--- a/content/020_prerequisites/aws_event/_index.md
+++ b/content/020_prerequisites/aws_event/_index.md
@@ -13,4 +13,8 @@ Kubecon, Immersion Day, or any other event hosted by an AWS employee). If you ar
 [Start the workshop on your own](../self_paced/).
 {{% /notice %}}
 
+{{% notice warning %}}
+From the following tasks you only need to complete the [Install Kubernetes Tools](https://www.eksworkshop.com/020_prerequisites/k8stools/) and [Clone the Service Repos](https://www.eksworkshop.com/020_prerequisites/clone/) since the IAM role and AWS KMS Key is already configured as part of the event stand up process.  ,.
+{{% /notice %}}
+
 {{% children %}}


### PR DESCRIPTION
The IAM role and KMS Keys comes by default in an AWS hosted event. No need for the attendees to go through the IAM and KMS tasks in the Start the workshop section.

*Issue #, if available:*
Attendees, in an AWS hosted event, get confused and lose time when going through IAM and KMS tasks in the Start the workshop section since those constructs come by default.


*Description of changes:*
Adding a warning message that the attendees need to complete only the Install Kubernetes Tools task and the Clone the Service Repos task.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
