### PR TITLE
jq syntax fix

### DIFF
--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -9,7 +9,7 @@ Before we install Karpenter, there are a few things that we will need to prepare
 ## Pre-requisites
 
 ```bash
-export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].metadata.name')
+export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].Name')
 export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query Account)
 export AWS_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
 ```


### PR DESCRIPTION
` eksctl get clusters -o json | jq -r `
returns e.g.
```
[
  {
    "Name": "eksworkshop-eksctl",
    "Region": "mars-west-1",
    "Owned": "False"
  }
]
```
That's why to get proper response you would need
`eksctl get clusters -o json | jq -r '.[0].Name'`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
