### PR TITLE
Update add helpful tip to eliminate error

### DIFF
--- a/content/beginner/091_iam-groups/test-cluster-access.md
+++ b/content/beginner/091_iam-groups/test-cluster-access.md
@@ -112,6 +112,7 @@ Let's create a pod:
 ```bash
 kubectl run --generator=run-pod/v1 nginx-dev --image=nginx -n development
 ```
+> Note: If you are getting an error "The connection to the server localhost:8080 was refused - did you specify the right host or port?", its possible that you have not cleaned up the environment from a previous lab. Please follow the steps required to clean up and then retry. 
 
 We can list the pods:
 


### PR DESCRIPTION
command "kubectl run --generator=run-pod/v1 nginx-dev --image=nginx -n development"
throws an error if the Cloud9 environment has not been cleaned up from a previous lab.
example : if you were doing the "090_rbac" lab and you skipped this steps "https://www.eksworkshop.com/beginner/090_rbac/cleanup/", you would get an error. Often times, a mock environment is set up for short duration so the clean up task is skipped and the audience/trainee is stuck with this error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
