### PR TITLE
Update setup_the_environment.md

### DIFF
--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -9,7 +9,7 @@ Before we install Karpenter, there are a few things that we will need to prepare
 ## Pre-requisites
 
 ```bash
-export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].metadata.name')
+export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].Name')
 export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query Account)
 export AWS_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
 ```


### PR DESCRIPTION
*Issue #, if available:*
cluster name is not embedded in metadata. It sends `null` response. 

```bash
~/Workspace/Experiments/eksworkshop ❯ export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].metadata.name')
export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query Account)
2022-03-28 15:15:44 [ℹ]  eksctl version 0.86.0
2022-03-28 15:15:44 [ℹ]  using region ap-southeast-1
```

This errors out while updating subnets:

```zsh
~/Workspace/Experiments/eksworkshop ❯ SUBNET_IDS=$(aws cloudformation describe-stacks \
    --stack-name eksctl-${CLUSTER_NAME}-cluster \
    --query 'Stacks[].Outputs[?OutputKey==`SubnetsPrivate`].OutputValue' \
    --output text)
aws ec2 create-tags \
    --resources $(echo $SUBNET_IDS | tr ',' '\n') \
    --tags Key="kubernetes.io/cluster/${CLUSTER_NAME}",Value=

An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id eksctl-null-cluster does not exist

An error occurred (MissingParameter) when calling the CreateTags operation: The request must contain the parameter resourceIdSet
```

*Description of changes:*
Update the calling query:

```bash
~/Workspace/Experiments/eksworkshop ❯ eksctl get clusters -o json | jq -r '.[0]'                                                  7s
2022-03-28 15:18:47 [ℹ]  eksctl version 0.86.0
2022-03-28 15:18:47 [ℹ]  using region ap-southeast-1
{
  "Name": "eksworkshop-eksctl-deep",
  "Region": "ap-southeast-1",
  "Owned": "False"
}
~/Workspace/Experiments/eksworkshop ❯ eksctl get clusters -o json | jq -r '.[0].Name'                                            11s
2022-03-28 15:19:02 [ℹ]  eksctl version 0.86.0
2022-03-28 15:19:02 [ℹ]  using region ap-southeast-1
eksworkshop-eksctl-deep
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
