### PR TITLE
InstanceProfile URL update for Karpenter

### DIFF
--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -39,11 +39,14 @@ echo "$SUBNET_IDS == $VALIDATION_SUBNETS_IDS"
 
 ## Create the IAM Role and Instance profile for Karpenter Nodes 
 
-Instances launched by Karpenter must run with an InstanceProfile that grants permissions necessary to run containers and configure networking. Karpenter discovers the InstanceProfile using the name `KarpenterNodeRole-${ClusterName}`.
+Instances launched by Karpenter must run with an InstanceProfile that grants permissions necessary to run containers and configure networking. Karpenter discovers the InstanceProfile using the name `KarpenterNodeRole-${ClusterName}`. 
 
 ```bash
 TEMPOUT=$(mktemp)
-curl -fsSL https://karpenter.sh/docs/getting-started/cloudformation.yaml > $TEMPOUT \
+
+export KARPENTER_VERSION=v0.7.3
+
+curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-started-with-eksctl/cloudformation.yaml  > $TEMPOUT \
 && aws cloudformation deploy \
   --stack-name Karpenter-${CLUSTER_NAME} \
   --template-file ${TEMPOUT} \


### PR DESCRIPTION
*Issue #, if available:*
Cloudformation URL for `karpenter` has changed. With current file you get below error:

```bash
~/Workspace/Experiments/eksworkshop ❯ TEMPOUT=$(mktemp)
curl -fsSL https://karpenter.sh/docs/getting-started/cloudformation.yaml > $TEMPOUT \
&& aws cloudformation deploy \
  --stack-name Karpenter-${CLUSTER_NAME} \
  --template-file ${TEMPOUT} \
  --capabilities CAPABILITY_NAMED_IAM \
  --parameter-overrides ClusterName=${CLUSTER_NAME}
curl: (22) The requested URL returned error: 404
~/Workspace/Experiments/eksworkshop ❯ TEMPOUT=$(mktemp)

~/Workspace/Experiments/eksworkshop ❯ curl -fsSL https://karpenter.sh/docs/getting-started/cloudformation.yaml > $TEMPOUT
curl: (22) The requested URL returned error: 404
```

*Description of changes:*
New URL requires version details as well. Hence it should be updated to below:

```bash
~/Workspace/Experiments/eksworkshop ❯ export KARPENTER_VERSION=v0.7.3

~/Workspace/Experiments/eksworkshop ❯ curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-started-with-eksctl/cloudformation.yaml  > $TEMPOUT \
&& aws cloudformation deploy \
  --stack-name "Karpenter-${CLUSTER_NAME}" \
  --template-file "${TEMPOUT}" \
  --capabilities CAPABILITY_NAMED_IAM \
  --parameter-overrides "ClusterName=${CLUSTER_NAME}"

Waiting for changeset to be created..
Waiting for stack create/update to complete
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
