### PR TITLE
Upgrade aws lb controller

### DIFF
--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -67,5 +67,6 @@ kubectl completion bash >>  ~/.bash_completion
 
 ```bash
 echo 'export LBC_VERSION="v2.4.1"' >>  ~/.bash_profile
+echo 'export LBC_CHART_VERSION="1.4.1"' >>  ~/.bash_profile
 .  ~/.bash_profile
 ```

--- a/content/020_prerequisites/k8stools.md
+++ b/content/020_prerequisites/k8stools.md
@@ -66,6 +66,6 @@ kubectl completion bash >>  ~/.bash_completion
 #### set the AWS Load Balancer Controller version
 
 ```bash
-echo 'export LBC_VERSION="v2.4.0"' >>  ~/.bash_profile
+echo 'export LBC_VERSION="v2.4.1"' >>  ~/.bash_profile
 .  ~/.bash_profile
 ```

--- a/content/beginner/130_exposing-service/cleaning.md
+++ b/content/beginner/130_exposing-service/cleaning.md
@@ -17,13 +17,13 @@ rm ~/environment/run-my-nginx.yaml
 export EKS_CLUSTER_VERSION=$(aws eks describe-cluster --name eksworkshop-eksctl --query cluster.version --output text)
 
 if [ "`echo "${EKS_CLUSTER_VERSION} < 1.19" | bc`" -eq 1 ]; then     
-    curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full.yaml \
+    curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.3.1/docs/examples/2048/2048_full.yaml \
     | sed 's=alb.ingress.kubernetes.io/target-type: ip=alb.ingress.kubernetes.io/target-type: instance=g' \
     | kubectl delete -f -
 fi
 
 if [ "`echo "${EKS_CLUSTER_VERSION} >= 1.19" | bc`" -eq 1 ]; then     
-    curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full_latest.yaml \
+    curl -s https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.3.1/docs/examples/2048/2048_full_latest.yaml \
     | sed 's=alb.ingress.kubernetes.io/target-type: ip=alb.ingress.kubernetes.io/target-type: instance=g' \
     | kubectl delete -f -
 fi

--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -83,7 +83,7 @@ Learn more about [IAM Roles for Service Accounts](https://docs.aws.amazon.com/ek
 Create a policy called **AWSLoadBalancerControllerIAMPolicy**
 
 ```bash
-curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.3.0/docs/install/iam_policy.json
+curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.1/docs/install/iam_policy.json
 aws iam create-policy \
     --policy-name AWSLoadBalancerControllerIAMPolicy \
     --policy-document file://iam_policy.json

--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -122,7 +122,8 @@ helm upgrade -i aws-load-balancer-controller \
     --set clusterName=eksworkshop-eksctl \
     --set serviceAccount.create=false \
     --set serviceAccount.name=aws-load-balancer-controller \
-    --set image.tag="${LBC_VERSION}"
+    --set image.tag="${LBC_VERSION}" \
+    --version="${LBC_CHART_VERSION}"
 
 kubectl -n kube-system rollout status deployment aws-load-balancer-controller
 ```

--- a/content/beginner/130_exposing-service/ingress_controller_alb.md
+++ b/content/beginner/130_exposing-service/ingress_controller_alb.md
@@ -83,7 +83,7 @@ Learn more about [IAM Roles for Service Accounts](https://docs.aws.amazon.com/ek
 Create a policy called **AWSLoadBalancerControllerIAMPolicy**
 
 ```bash
-curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.1/docs/install/iam_policy.json
+curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/${LBC_VERSION}/docs/install/iam_policy.json
 aws iam create-policy \
     --policy-name AWSLoadBalancerControllerIAMPolicy \
     --policy-document file://iam_policy.json

--- a/content/beginner/180_fargate/prerequisites-for-alb.md
+++ b/content/beginner/180_fargate/prerequisites-for-alb.md
@@ -52,7 +52,7 @@ The next step is to create the IAM policy that will be used by the AWS Load Bala
 This policy will be later associated to the Kubernetes Service Account and will allow the controller pods to create and manage the ELB’s resources in your AWS account for you.
 
 ```bash
-curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.0/docs/install/iam_policy.json
+curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/${LBC_VERSION}/docs/install/iam_policy.json
 aws iam create-policy \
     --policy-name AWSLoadBalancerControllerIAMPolicy \
     --policy-document file://iam_policy.json
@@ -142,7 +142,8 @@ helm upgrade -i aws-load-balancer-controller \
     --set serviceAccount.name=aws-load-balancer-controller \
     --set image.tag="${LBC_VERSION}" \
     --set region=${AWS_REGION} \
-    --set vpcId=${VPC_ID}
+    --set vpcId=${VPC_ID} \
+    --version="${LBC_CHART_VERSION}"
 ```
 
 You can check if the `deployment` has completed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed the content to install AWS Load Balancer Controller v2.4.1 instead of v2.4.0. Before this change, the instructions in "Install Kubernetes Tools" page were referring to v2.4.0, but the instructions in "Ingress Controller" page were referring to v2.3.0. Also, the latest version of the helm chart was used which does not align with v2.4.0 of the AWS Load Balancer Controller. I explicitly specified the version of the helm chart to avoid the re-occurrence of this issue. I also changed the content of the Fargate lab to align with these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
