### PR TITLE
Update Cluster Name extraction query

### DIFF
--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -9,7 +9,7 @@ Before we install Karpenter, there are a few things that we will need to prepare
 ## Pre-requisites
 
 ```bash
-export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].metadata.name')
+export CLUSTER_NAME=$(eksctl get clusters -o json | jq -r '.[0].Name')
 export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query Account)
 export AWS_REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
 ```


### PR DESCRIPTION
As of today, the Cluster Name extraction query result in "null" because [0].metadata.name results in the same. 
The JSON has a field called 'Name' which starts with an upperCase N. 

{
  "Name": "sample-eksctl",
  "Region": "us-west-2",
  "Owned": "True"
}

Modified the command  to   [0].Name' that results in the proper extraction.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
