### PR TITLE
access key output on right path

### DIFF
--- a/content/beginner/090_rbac/create_iam_user.md
+++ b/content/beginner/090_rbac/create_iam_user.md
@@ -14,7 +14,7 @@ From within the Cloud9 terminal, create a new user called rbac-user, and generat
 ```
 aws iam create-user --user-name rbac-user
 mkdir tmp
-aws iam create-access-key --user-name rbac-user | tee tmp/create_output.json
+aws iam create-access-key --user-name rbac-user | tee /tmp/create_output.json
 ```
 
 By running the previous step, you should get a response similar to:


### PR DESCRIPTION
Access key is getting created in the wrong path, usually the user won't be in the / directory.
and as we are creating it  at "tmp/create_output.json", this will create the folder inside the working directory.
But after my updates it will be created at the right place

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
