### PR TITLE
Fix yq command in tutorial

### DIFF
--- a/content/beginner/160_advanced-networking/secondary_cidr/eniconfig_crd.md
+++ b/content/beginner/160_advanced-networking/secondary_cidr/eniconfig_crd.md
@@ -80,7 +80,7 @@ Note: We are using same SecurityGroup for pods as your Worker Nodes but you can 
  
 Check the `yq` command runs successfully. Refer to `yq` setup in [Install Kubernetes Tools](https://www.eksworkshop.com/020_prerequisites/k8stools/)
 ```
-yq help >/dev/null  && echo "yq command working" || "yq command not working"
+yq --help >/dev/null  && echo "yq command working" || "yq command not working"
 ```
 {{< output >}}
  yq command working


### PR DESCRIPTION
* Latest yq uses `yq --help` to bring up help, not `yq help`
* See yq docs: https://mikefarah.gitbook.io/yq/commands/evaluate-all#flags 