### PR TITLE
Change the helm chart repository URL

### DIFF
--- a/content/beginner/194_secrets_manager/configure-csi-driver.md
+++ b/content/beginner/194_secrets_manager/configure-csi-driver.md
@@ -12,7 +12,7 @@ Prepare your cluster by installing Secrets Store CSI Secret driver and AWS Secre
 
 ```bash
 helm repo add secrets-store-csi-driver \
-  https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+  https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
 
 helm install -n kube-system csi-secrets-store \
   --set syncSecret.enabled=true \


### PR DESCRIPTION
According to https://secrets-store-csi-driver.sigs.k8s.io/getting-started/upgrades.html the helm chart repository URL has changed to https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
