### PR TITLE
Update controller to version 0.17.5

### DIFF
--- a/content/beginner/200_secrets/installing-sealed-secrets.md
+++ b/content/beginner/200_secrets/installing-sealed-secrets.md
@@ -8,7 +8,8 @@ draft: false
 #### Installing the kubeseal Client
 For Linux x86_64 systems, the client-tool may be installed into /usr/local/bin with the following command:
 ```
-wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.16.0/kubeseal-linux-amd64 -O kubeseal
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.5/kubeseal-0.17.5-linux-amd64.tar.gz -O kubeseal.tar.gz
+tar xvzf kubeseal.tar.gz
 sudo install -m 755 kubeseal /usr/local/bin/kubeseal
 ```
 For MacOS systems, the client-tool is installed as follows:
@@ -19,7 +20,7 @@ brew install kubeseal
 #### Installing the Custom Controller and CRD for SealedSecret
 Install the SealedSecret CRD, controller and RBAC artifacts on your EKS cluster as follows:
 ```
-wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.16.0/controller.yaml
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.5/controller.yaml
 kubectl apply -f controller.yaml
 ```
 


### PR DESCRIPTION
Version 0.16.0 uses an image quay.io/bitnami/sealed-secrets-controller:v0.16.0 which returns 403: Unauthorized.
Version 0.17.5 uses the image from docker.io/bitnami/sealed-secrets-controller:v0.17.5

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
