### PR TITLE
Kube bench - Update to EKS 1.0.1 benchmark

### DIFF
--- a/content/intermediate/300_cis_eks_benchmark/debug-mode.md
+++ b/content/intermediate/300_cis_eks_benchmark/debug-mode.md
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: kube-bench
           image: aquasec/kube-bench:latest
-          command: ["kube-bench", "-v", "3", "--logtostderr", "--benchmark", "eks-1.0"]
+          command: ["kube-bench", "-v", "3", "--logtostderr", "--benchmark", "eks-1.0.1"]
           volumeMounts:
             - name: var-lib-kubelet
               mountPath: /var/lib/kubelet

--- a/content/intermediate/300_cis_eks_benchmark/intro.md
+++ b/content/intermediate/300_cis_eks_benchmark/intro.md
@@ -12,7 +12,7 @@ The latest version of CIS Kubernetes Benchmark [v1.5.1](https://www.cisecurity.o
 
 Since Amazon EKS provides a managed control plane, not all of the recommendations from the CIS Kubernetes Benchmark are applicable as customers are not responsible for configuring or managing the control plane. 
 
-CIS Amazon EKS Benchmark [v1.0.0](https://www.cisecurity.org/cis-benchmarks/) provides guidance for node security configurations for Kubernetes and aligns with CIS Kubernetes Benchmark v1.5.1.
+CIS Amazon EKS Benchmark [v1.0.1](https://www.cisecurity.org/cis-benchmarks/) provides guidance for node security configurations for Kubernetes and aligns with CIS Kubernetes Benchmark v1.5.1.
 
 {{% notice info %}}
 Note: The CIS committee agreed to remove controls for the appropriate control plane recommendations from the managed Kubernetes benchmarks. The CIS Amazon EKS Benchmark consists of four sections on control plane logging configuration, worker nodes, policies and managed services. 

--- a/content/intermediate/300_cis_eks_benchmark/run-as-job.md
+++ b/content/intermediate/300_cis_eks_benchmark/run-as-job.md
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: kube-bench
           image: aquasec/kube-bench:latest
-          command: ["kube-bench", "--benchmark", "eks-1.0"]
+          command: ["kube-bench", "--benchmark", "eks-1.0.1"]
           volumeMounts:
             - name: var-lib-kubelet
               mountPath: /var/lib/kubelet

--- a/content/intermediate/300_cis_eks_benchmark/ssh-into-node.md
+++ b/content/intermediate/300_cis_eks_benchmark/ssh-into-node.md
@@ -38,12 +38,12 @@ KUBEBENCH_URL=$(curl -s https://api.github.com/repos/aquasecurity/kube-bench/rel
 sudo yum install -y $KUBEBENCH_URL
 ```
 
-#### Run assessment against `eks-1.0`
+#### Run assessment against `eks-1.0.1`
 
-Run the assessment against `eks-1.0` controls based on CIS Amazon EKS Benchmark node assessments.
+Run the assessment against `eks-1.0.1` controls based on CIS Amazon EKS Benchmark node assessments.
 
 ```
-kube-bench --benchmark eks-1.0
+kube-bench --benchmark eks-1.0.1
 ```
 
 ##### Output


### PR DESCRIPTION
Issue: Error while trying to run kube-bench with provided instructions

```
$ kube-bench --benchmark eks-1.0

error validating targets: No targets configured for eks-1.0
```

The latest EKS benchmark available in kube-bench is 1.0.1.

I updated the different instructions and config fils to refer to this version. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
