### PR TITLE
Update controler to 0.18.0

### DIFF
--- a/content/beginner/200_secrets/installing-sealed-secrets.md
+++ b/content/beginner/200_secrets/installing-sealed-secrets.md
@@ -19,7 +19,7 @@ brew install kubeseal
 #### Installing the Custom Controller and CRD for SealedSecret
 Install the SealedSecret CRD, controller and RBAC artifacts on your EKS cluster as follows:
 ```
-wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.16.0/controller.yaml
+wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.18.0/controller.yaml
 kubectl apply -f controller.yaml
 ```
 


### PR DESCRIPTION
With 0.16.0 there are few errors like
resource mapping not found for name: "sealed-secrets-service-proxier" namespace: "kube-system" from "controller.yaml": no matches for kind "Role" in version "rbac.authorization.k8s.io/v1beta1" ensure CRDs are installed first
...

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
