### PR TITLE
fixed deprecated versioning on SecretProviderClass

### DIFF
--- a/content/beginner/194_secrets_manager/deploy-workload-secret.md
+++ b/content/beginner/194_secrets_manager/deploy-workload-secret.md
@@ -11,7 +11,7 @@ Create SecretProviderClass custom resource with ```provider:aws``` . The SecretP
 ```bash
 cat << EOF > nginx-deployment-spc.yaml
 ---
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: nginx-deployment-spc

--- a/content/beginner/194_secrets_manager/sync_native_secrets_env.md
+++ b/content/beginner/194_secrets_manager/sync_native_secrets_env.md
@@ -20,7 +20,7 @@ Let's create a SecretProviderClass custom resource and use ```jmesPath``` field 
 
 ```bash
 cat << EOF > nginx-deployment-spc-k8s-secrets.yaml
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: nginx-deployment-spc-k8s-secrets


### PR DESCRIPTION
*Issue #, if available:*
Workshop using deprecated version of SecretStoreProvider in K8s 1.21.

*Description of changes:*
Updated to v1 from v1alpha1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
