### PR TITLE
EFS/CSI driver version for 1.21 and beyond is 1.3.

### DIFF
--- a/content/beginner/190_efs/efs-csi-driver.md
+++ b/content/beginner/190_efs/efs-csi-driver.md
@@ -13,7 +13,7 @@ On Amazon EKS, the open-source [EFS Container Storage Interface (CSI)](https://g
 We are going to deploy the driver using the stable release:
 
 ```
-kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.0"
+kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.3"
 ```
 
 Verify pods have been deployed:


### PR DESCRIPTION
changing to kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.3"
Source : https://github.com/kubernetes-sigs/aws-efs-csi-driver

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
