### PR TITLE
Hostname binary is not included in mysql image

### DIFF
--- a/content/beginner/170_statefulset/statefulset.files/mysql-statefulset.yaml
+++ b/content/beginner/170_statefulset/statefulset.files/mysql-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         - |
           set -ex
           # Generate mysql server-id from pod ordinal index.
-          [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+          [[ $HOSTNAME =~ -([0-9]+)$ ]] || exit 1
           ordinal=${BASH_REMATCH[1]}
           echo [mysqld] > /mnt/conf.d/server-id.cnf
           # Add an offset to avoid reserved server-id=0 value.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Missing hostname binary causes init-contaienr to exit/crash and prevent startup of rest of containers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
