### PR TITLE
Update dashboard version

### DIFF
--- a/content/beginner/040_dashboard/dashboard.md
+++ b/content/beginner/040_dashboard/dashboard.md
@@ -10,7 +10,7 @@ instructions in [the official documentation](https://kubernetes.io/docs/tasks/ac
 We can deploy the dashboard with the following command:
 
 ```bash
-export DASHBOARD_VERSION="v2.0.0"
+export DASHBOARD_VERSION="v2.2.0"
 
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/${DASHBOARD_VERSION}/aio/deploy/recommended.yaml
 ```


### PR DESCRIPTION
Update dashboard version from v2.0.0 to v2.2.0 as stated in the k8s 1.21 dash docs:
https://v1-21.docs.kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
