### PR TITLE
Docs fix

### DIFF
--- a/content/beginner/060_helm/helm_nginx/installnginx.md
+++ b/content/beginner/060_helm/helm_nginx/installnginx.md
@@ -59,7 +59,7 @@ To access NGINX from outside the cluster, follow the steps below:
 
 In order to review the underlying Kubernetes services, pods and deployments, run:
 ```sh
-kubectl get svc,po,deploy
+kubectl get svc,pod,deploy
 ```
 
 {{% notice info %}}

--- a/content/beginner/060_helm/helm_nginx/installnginx.md
+++ b/content/beginner/060_helm/helm_nginx/installnginx.md
@@ -53,7 +53,7 @@ To access NGINX from outside the cluster, follow the steps below:
         Watch the status with: 'kubectl get svc --namespace default -w mywebserver-nginx'
 
     export SERVICE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].port}" services mywebserver-nginx)
-    export SERVICE_IP=$(kubectl get svc --namespace default mywebserver-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    export SERVICE_IP=$(kubectl get svc --namespace default mywebserver-nginx -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
     echo "http://${SERVICE_IP}:${SERVICE_PORT}"
 {{< /output >}}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* fixed the command to get the external IP of the service
* changed `kubectl get po` to `kubectl get pod` in in order to improve clarity of the command and what does it do

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
