### PR TITLE
fix: change resource order to match the docs

### DIFF
--- a/content/beginner/060_helm/helm_nginx/installnginx.md
+++ b/content/beginner/060_helm/helm_nginx/installnginx.md
@@ -59,7 +59,7 @@ To access NGINX from outside the cluster, follow the steps below:
 
 In order to review the underlying Kubernetes services, pods and deployments, run:
 ```sh
-kubectl get svc,po,deploy
+kubectl get deploy,po,svc
 ```
 
 {{% notice info %}}


### PR DESCRIPTION
*Issue #, if available:*

The documentation on this [page](https://www.eksworkshop.com/beginner/060_helm/helm_nginx/installnginx/) says:

- "The first object shown in this output is a Deployment"
- "The next object shown created by the Chart is a Pod"
- "The third object that this Chart creates for us is a Service"

which does not match to the command it executes `kubectl get svc,po,deploy`
 
*Description of changes:*

Fixed the resource order in the command to avoid confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
