### PR TITLE
frontend deployment name update

### DIFF
--- a/content/beginner/060_helm/helm_micro/service.md
+++ b/content/beginner/060_helm/helm_micro/service.md
@@ -7,7 +7,7 @@ weight: 40
 To test the service our eksdemo Chart created, we'll need to get the name of the ELB endpoint that was generated when we deployed the Chart:
 
 ```sh
-kubectl get svc ecsdemo-frontend -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"; echo
+kubectl get svc eksdemo-frontend -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"; echo
 ```
 
 Copy that address, and paste it into a new tab in your browser.  You should see something similar to:


### PR DESCRIPTION
kubectl get svc eksdemo-frontend -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"; echo

*Issue #, if available:*
Command : kubectl get svc ecsdemo-frontend -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"; echo
Output : Error from server (NotFound): services "ecsdemo-frontend" not found

*Description of changes:*
Apparently, there is name change recently from ecsdemo to eksdemo , so command need to be updated accordingly
kubectl get svc eksdemo-frontend -o jsonpath="{.status.loadBalancer.ingress[*].hostname}"; echo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
