### PR TITLE
Suggestion to automate failure test

### DIFF
--- a/content/beginner/070_healthchecks/readinessprobe.md
+++ b/content/beginner/070_healthchecks/readinessprobe.md
@@ -79,6 +79,20 @@ Pick one of the pods from above 3 and issue a command as below to delete the **/
 kubectl exec -it <YOUR-READINESS-POD-NAME> -- rm /tmp/healthy
 ```
 
+Issue command(s) as below to delete the **/tmp/healthy** file from the oldest POD which makes the readiness probe fail.
+
+```
+OLDESTPOD=$(kubectl get pods -l app=readiness-deployment --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[0].metadata.name}")
+kubectl exec -it $OLDESTPOD -- rm /tmp/healthy
+```
+
+Alternatively, you can issue command(s) as below to delete the **/tmp/healthy** file from the most recent POD which makes the readiness probe fail.
+
+```
+NEWESTPOD=$(kubectl get pods -l app=readiness-deployment --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}")
+kubectl exec -it $NEWESTPOD -- rm /tmp/healthy
+```
+
 **readiness-deployment-7869b5d679-922mx** was picked in our example cluster. The **/tmp/healthy** file was deleted. This file must be present for the readiness check to pass. Below is the status after issuing the command.
 
 ```
@@ -116,6 +130,19 @@ Run the below command with the name of the pod to recreate the **/tmp/healthy** 
 ```
 kubectl exec -it <YOUR-READINESS-POD-NAME> -- touch /tmp/healthy
 ```
+
+Run the below command to recreate the **/tmp/healthy** file from the oldest POD. Once the pod passes the probe, it gets marked as ready and will begin to receive traffic again.
+
+```
+kubectl exec -it $OLDESTPOD -- touch /tmp/healthy
+```
+
+Alternatively, you can run the below command to recreate the **/tmp/healthy** file from the most recent POD.Once the pod passes the probe, it gets marked as ready and will begin to receive traffic again.
+
+```
+kubectl exec -it $NEWESTPOD -- touch /tmp/healthy
+```
+
 ```
 kubectl get pods -l app=readiness-deployment
 ```


### PR DESCRIPTION
Suggestion:
Automate process for oldest POD and/or most recent POD 
Since we are automating in most of the labs, why not automate here by issuing command for oldest POD and/or most recent POD

*Issue #, if available:*
Currently, command has a placeholder <YOUR-READINESS-POD-NAME> to test failure. Suggestion is to auotmate failure by using oldest pod $OLDESTPOD or newly created POD $NEWESTPOD

*Description of changes:*

OLDESTPOD=$(kubectl get pods -l app=readiness-deployment --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[0].metadata.name}")
kubectl exec -it $OLDESTPOD -- rm /tmp/healthy
kubectl exec -it $OLDESTPOD -- touch /tmp/healthy

NEWESTPOD=$(kubectl get pods -l app=readiness-deployment --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}")
kubectl exec -it $NEWESTPOD -- rm /tmp/healthy
kubectl exec -it $NEWESTPOD -- touch /tmp/healthy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
