### PR TITLE
Update cleanup steps for ArgoCD to match install

### DIFF
--- a/content/intermediate/290_argocd/cleanup.md
+++ b/content/intermediate/290_argocd/cleanup.md
@@ -19,7 +19,7 @@ FATA[0000] rpc error: code = NotFound desc = applications.argoproj.io "ecsdemo-n
 
 And then delete ArgoCD from your cluster:
 ```
-kubectl delete -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v2.0.4/manifests/install.yaml
+kubectl delete -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.7/manifests/install.yaml
 ```
 
 Delete namespaces created for this chapter:


### PR DESCRIPTION
Install steps used v2.4.7 manifest.  Updated cleanup steps to match.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
