### PR TITLE
Amend TEMPOUT parameter (ambiguous redirect error)

### DIFF
--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -28,7 +28,7 @@ Instances launched by Karpenter must run with an InstanceProfile that grants per
 First, create the IAM resources using AWS CloudFormation.
 
 ```bash
-TEMPOUT=$(mktemp)
+TEMPOUT="$(mktemp)"
 
 curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-started-with-eksctl/cloudformation.yaml  > $TEMPOUT \
 && aws cloudformation deploy \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Current parameter will provide this error:
TEMPOUT=$(mktemp)
>> bash: $TEMPOUT: ambiguous redirect
And fail the creation of Stackset

Fixing it into TEMPOUT="$(mktemp)"
Will allow the creation of the Stackset :

Waiting for changeset to be created..
Waiting for stack create/update to complete
Successfully created/updated stack - Karpenter-eksworkshop-eksctl

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
