### PR TITLE
To get IP address of LB use .ip not .hostname

### DIFF
--- a/content/intermediate/290_argocd/configure.md
+++ b/content/intermediate/290_argocd/configure.md
@@ -15,7 +15,7 @@ kubectl patch svc argocd-server -n argocd -p '{"spec": {"type": "LoadBalancer"}}
 
 Wait about 2 minutes for the LoadBalancer creation
 ```
-export ARGOCD_SERVER=`kubectl get svc argocd-server -n argocd -o json | jq --raw-output '.status.loadBalancer.ingress[0].hostname'`
+export ARGOCD_SERVER=`kubectl get svc argocd-server -n argocd -o json | jq --raw-output '.status.loadBalancer.ingress[0].ip'`
 ```
 
 ### Login


### PR DESCRIPTION
*Tested on AKS not EKS yet*
hostname will yield null result, ip should get you correct result $kubectl get svc argocd-server -n argocd -o json | jq --raw-output '.status.loadBalancer.ingress[0].hostname' null

Sample output from AKS
"status": {
        "loadBalancer": {
            "ingress": [
                {
                    "ip": "20.x.xx.xx"
                }
            ]
        }

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
