### PR TITLE
failed to run helm install kube-ops-view

### DIFF
--- a/content/beginner/080_scaling/install_kube_ops_view.md
+++ b/content/beginner/080_scaling/install_kube_ops_view.md
@@ -14,6 +14,8 @@ We will deploy kube-ops-view using `Helm` configured in a previous [module](/beg
 The following line updates the stable helm repository and then installs kube-ops-view using a LoadBalancer Service type and creating a RBAC (Resource Base Access Control) entry for the read-only service account to read nodes and pods information from the cluster.
 
 ```
+helm repo add stable https://charts.helm.sh/stable
+
 helm install kube-ops-view \
 stable/kube-ops-view \
 --set service.type=LoadBalancer \


### PR DESCRIPTION
*Issue #, if available:*
Fixed: #1508

*Description of changes:*

```
➜  helm install kube-ops-view \
stable/kube-ops-view \
--set service.type=LoadBalancer \
--set rbac.create=True
Error: INSTALLATION FAILED: repo stable not found
➜  helm repo add stable https://kubernetes-charts.storage.googleapis.com/
Error: repo "https://kubernetes-charts.storage.googleapis.com/" is no longer available; try "https://charts.helm.sh/stable" instead
➜  helm repo add stable https://charts.helm.sh/stable                    
"stable" has been added to your repositories
➜  helm install kube-ops-view \                                          
stable/kube-ops-view \
--set service.type=LoadBalancer \
--set rbac.create=True
WARNING: This chart is deprecated
W1031 00:15:08.171174   96265 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W1031 00:15:08.324279   96265 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W1031 00:15:09.151760   96265 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W1031 00:15:09.312256   96265 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
NAME: kube-ops-view
LAST DEPLOYED: Mon Oct 31 00:15:07 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To access the Kubernetes Operational View UI:

1. First start the kubectl proxy:

   kubectl proxy

2. Now open the following URL in your browser:

   http://localhost:8001/api/v1/proxy/namespaces/default/services/kube-ops-view/

````
