### PR TITLE
Updated "Download" to "Add"

### DIFF
--- a/content/beginner/060_helm/helm_intro/install.md
+++ b/content/beginner/060_helm/helm_intro/install.md
@@ -22,7 +22,7 @@ Let's configure our first Chart repository. Chart repositories are similar to
 APT or yum repositories that you might be familiar with on Linux, or Taps for
 Homebrew on macOS.
 
-Download the `stable` repository so we have something to start with:
+Add the `stable` repository so we have something to start with:
 
 ```sh
 helm repo add stable https://charts.helm.sh/stable


### PR DESCRIPTION
For folks familiar with disconnected installs, etc.. the word Download kind of implies that perhaps we would mirror/download the actual repo - not simply configuring it to be available.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
