### PR TITLE
Add procedure to delete pod (demonstrate autorecovery)

### DIFF
--- a/content/beginner/070_healthchecks/readinessprobe.md
+++ b/content/beginner/070_healthchecks/readinessprobe.md
@@ -120,3 +120,16 @@ kubectl exec -it <YOUR-READINESS-POD-NAME> -- touch /tmp/healthy
 kubectl get pods -l app=readiness-deployment
 ```
 {{% /expand %}}
+
+**How would you restore the pod to Ready status (alternate-method)?**
+{{%expand "Expand here to see the solution" %}}
+Run the below command with the name of the pod to recreate the **pod** (be deleting it). Once the pod passes the probe, it gets marked as ready and will begin to receive traffic again.
+
+```
+kubectl delete pod <YOUR-READINESS-POD-NAME>
+```
+
+```
+kubectl get pods -l app=readiness-deployment -w
+```
+{{% /expand %}}


### PR DESCRIPTION
I think it would be cool and advantageous to demonstrate how the cluster can/will respond when the pod is deleted.

*Issue #, if available:*
 This is not an issue.
 
*Description of changes:*
I have added a section after the original recovery method (touch /tmp/health) to demonstrate how to delete the pod and let the cluster recreate the pod.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
