### PR TITLE
Adding Windows Container on AWS Workshop

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -108,9 +108,14 @@ url = "https://awsworkshop.io"
 weight = 10
 
 [[menu.shortcuts]]
+name = "<i class='fas fa-chalkboard'></i> Windows containers on AWS Workshops"
+url = "https://ms-containers.workshop.aws"
+weight = 11
+
+[[menu.shortcuts]]
 name = "<i class='fas fa-chalkboard'></i> EKS Anywhere"
 url = "https://anywhere.eks.amazonaws.com/docs/getting-started/"
-weight = 11
+weight = 12
 
 [[menu.shortcuts]]
 name = "<i class='fas fa-bookmark'></i> More Resources"


### PR DESCRIPTION
The Windows container on AWS workshop is a well-know workshop already delivered on re:invent 2021 and 2022.

*Issue #, if available:*

*Description of changes:*
Adding the Windows containers on AWS hyperlink.
The Windows container on AWS workshop is a well-know workshop already delivered on re:invent 2021 and 2022. 
URL: ms-containers.workshop.aws/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
