### PR TITLE
Update setup_the_environment.md

### DIFF
--- a/content/beginner/085_scaling_karpenter/setup_the_environment.md
+++ b/content/beginner/085_scaling_karpenter/setup_the_environment.md
@@ -10,7 +10,7 @@ Before we install Karpenter, there are a few things that we will need to prepare
 
 Set the following environment variable to the Karpenter version you would like to install.
 ```bash
-export KARPENTER_VERSION=v0.16.0
+export KARPENTER_VERSION=v0.20.0
 ```
 
 Also set the following environment variables to store commonly used values.


### PR DESCRIPTION
Getting 404 not found error with the following link, the page doesn't exist anymore on the karpenter website. pages for v0.20.0 and v.0.21.1 works.

`https://karpenter.sh/v0.16.0/getting-started/getting-started-with-eksctl/cloudformation.yaml`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
