### PR TITLE
Update images to use new registry

### DIFF
--- a/content/beginner/080_scaling/deploy_ca.files/cluster-autoscaler-autodiscover.yaml
+++ b/content/beginner/080_scaling/deploy_ca.files/cluster-autoscaler-autodiscover.yaml
@@ -74,10 +74,11 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create","list","watch"]
+    verbs: ["create", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    resourceNames:
+      ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
     verbs: ["delete", "get", "update", "watch"]
 
 ---
@@ -133,12 +134,12 @@ spec:
       labels:
         app: cluster-autoscaler
       annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/port: '8085'
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8085"
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.3
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.20.3
           name: cluster-autoscaler
           resources:
             limits:

--- a/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
+++ b/content/beginner/080_scaling/deploy_ca.files/cluster_autoscaler.yml
@@ -15,40 +15,47 @@ metadata:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
 rules:
-- apiGroups: [""]
-  resources: ["events","endpoints"]
-  verbs: ["create", "patch"]
-- apiGroups: [""]
-  resources: ["pods/eviction"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["pods/status"]
-  verbs: ["update"]
-- apiGroups: [""]
-  resources: ["endpoints"]
-  resourceNames: ["cluster-autoscaler"]
-  verbs: ["get","update"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["watch","list","get","update"]
-- apiGroups: [""]
-  resources: ["pods","services","replicationcontrollers","persistentvolumeclaims","persistentvolumes"]
-  verbs: ["watch","list","get"]
-- apiGroups: ["extensions"]
-  resources: ["replicasets","daemonsets"]
-  verbs: ["watch","list","get"]
-- apiGroups: ["policy"]
-  resources: ["poddisruptionbudgets"]
-  verbs: ["watch","list"]
-- apiGroups: ["apps"]
-  resources: ["statefulsets","replicasets","daemonsets"]
-  verbs: ["watch","list","get"]
-- apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses", "csinodes"]
-  verbs: ["watch","list","get"]
-- apiGroups: ["batch","extensions"]
-  resources: ["jobs"]
-  verbs: ["watch","list","get","patch"]
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      [
+        "pods",
+        "services",
+        "replicationcontrollers",
+        "persistentvolumeclaims",
+        "persistentvolumes",
+      ]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["watch", "list", "get", "patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -60,13 +67,14 @@ metadata:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
 rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create","list","watch"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: ["cluster-autoscaler-status","cluster-autoscaler-priority-expander"]
-  verbs: ["delete","get","update","watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames:
+      ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -123,7 +131,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v${AUTOSCALER_VERSION}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v${AUTOSCALER_VERSION}
           name: cluster-autoscaler
           resources:
             limits:
@@ -151,5 +159,3 @@ spec:
         - name: ssl-certs
           hostPath:
             path: "/etc/ssl/certs/ca-bundle.crt"
-
-

--- a/content/beginner/080_scaling/deploy_ca.md
+++ b/content/beginner/080_scaling/deploy_ca.md
@@ -27,6 +27,7 @@ aws autoscaling \
 
 {{< output >}}
 -------------------------------------------------------------
+
 |                 DescribeAutoScalingGroups                 |
 +-------------------------------------------+----+----+-----+
 |  eks-1eb9b447-f3c1-0456-af77-af0bbd65bc9f |  2 |  4 |  3  |
@@ -157,7 +158,7 @@ export AUTOSCALER_VERSION="1.21.2"
 
 kubectl -n kube-system \
     set image deployment.apps/cluster-autoscaler \
-    cluster-autoscaler=us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v${AUTOSCALER_VERSION}
+    cluster-autoscaler=registry.k8s.io/autoscaling/cluster-autoscaler:v${AUTOSCALER_VERSION}
 ```
 
 Watch the logs

--- a/content/beginner/140_assigning_pods/affinity.md
+++ b/content/beginner/140_assigning_pods/affinity.md
@@ -69,7 +69,7 @@ spec:
             - another-node-label-value
   containers:
   - name: with-node-affinity
-    image: us.gcr.io/k8s-artifacts-prod/pause:2.0
+    image: registry.k8s.io/pause:2.0
 EoF
 ```
 
@@ -121,7 +121,6 @@ NAME                 READY   STATUS    RESTARTS   AGE     IP                NODE
 nginx                1/1     Running   0          2m14s   192.168.155.38    ip-192-168-155-36.us-east-2.compute.internal    <none>           <none>
 with-node-affinity   1/1     Running   0          11s     192.168.166.141   ip-192-168-168-110.us-east-2.compute.internal   <none>           <none>
 {{< /output >}}
-
 
 You can see the operator `In` being used in the example.
 


### PR DESCRIPTION
This repository is in maintenance mode and currently only accepting bug-fixes. PRs for new content should be adapted for the new EKS Workshop: https://github.com/aws-samples/eks-workshop-v2

*Issue #, if available:*

*Description of changes:*
Updated images that were being pulled from k8s.gcr.io and us.gcr.io to use the new registry.k8s.io. Verified images existed via https://explore.ggcr.dev/?repo=registry.k8s.io and pulling locally with docker.

There's also a bunch of automatica yaml formatting that got saved. If you want me to remove that I can 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
